### PR TITLE
Fix errors in SHMEM collecives in transpose and p2p

### DIFF
--- a/SHMEM/Synch_p2p/p2p.c
+++ b/SHMEM/Synch_p2p/p2p.c
@@ -144,15 +144,15 @@ int main(int argc, char ** argv)
   }
 
 // initialize sync variables for error checks
-  pSync = (long *)   shmalloc ( sizeof(long) * SHMEM_BCAST_SYNC_SIZE );
-  pWrk  = (double *) shmalloc ( sizeof(double) * SHMEM_BCAST_SYNC_SIZE );
+  pSync = (long *)   shmalloc ( sizeof(long) * SHMEM_REDUCE_SYNC_SIZE );
+  pWrk  = (double *) shmalloc ( sizeof(double) * SHMEM_REDUCE_MIN_WRKDATA_SIZE );
   if (!pSync || !pWrk) {
     printf("Rank %d could not allocate work space for collectives\n", my_ID);
     error = 1;
     goto ENDOFTESTS;
   }
   for (i = 0; i < SHMEM_BCAST_SYNC_SIZE; i += 1) {
-    pSync[i] = _SHMEM_SYNC_VALUE;
+    pSync[i] = SHMEM_SYNC_VALUE;
   }
 
   if (m<=Num_procs) {


### PR DESCRIPTION
pSync and pWrk arrays were not sized correctly, leading to memory
corruption.  pSync arrays also do not need to be re-initialized after
they are used.  _SHMEM_* constants are deprecated; replaced with new
SHMEM_ constants, if SHMEM_ was already used in the same file.

Signed-off-by: James Dinan <james.dinan@intel.com>