### PR TITLE
New MPI-2 workarounds

### DIFF
--- a/MPIRMA/Stencil/stencil.c
+++ b/MPIRMA/Stencil/stencil.c
@@ -317,7 +317,7 @@ int main(int argc, char ** argv) {
   MPI_Info_set(rma_winfo, "no_locks", "true");
 
   /* allocate communication buffers for halo values                            */
-  MPI_Win_allocate(4*sizeof(DTYPE)*RADIUS*width, sizeof(DTYPE), rma_winfo, MPI_COMM_WORLD, (void *) &top_buf_out, &rma_winy);
+  PRK_Win_allocate(4*sizeof(DTYPE)*RADIUS*width, sizeof(DTYPE), rma_winfo, MPI_COMM_WORLD, (void *) &top_buf_out, &rma_winy);
   if (!top_buf_out) {
     printf("ERROR: Rank %d could not allocated comm buffers for y-direction\n", my_ID);
     error = 1;
@@ -327,7 +327,7 @@ int main(int argc, char ** argv) {
   bottom_buf_out = top_buf_out + 2*RADIUS*width;
   bottom_buf_in  = top_buf_out + 3*RADIUS*width;
  
-  MPI_Win_allocate(4*sizeof(DTYPE)*RADIUS*height, sizeof(DTYPE), rma_winfo, MPI_COMM_WORLD, (void *) &right_buf_out, &rma_winx);
+  PRK_Win_allocate(4*sizeof(DTYPE)*RADIUS*height, sizeof(DTYPE), rma_winfo, MPI_COMM_WORLD, (void *) &right_buf_out, &rma_winx);
   if (!right_buf_out) {
     printf("ERROR: Rank %d could not allocated comm buffers for x-direction\n", my_ID);
     error = 1;
@@ -470,8 +470,8 @@ int main(int argc, char ** argv) {
            1.0E-06 * flops/avgtime, avgtime);
   }
  
-  MPI_Win_free(&rma_winx);
-  MPI_Win_free(&rma_winy);
+  PRK_Win_free(&rma_winx);
+  PRK_Win_free(&rma_winy);
 
   MPI_Info_free(&rma_winfo);
 

--- a/MPIRMA/Synch_p2p/p2p.c
+++ b/MPIRMA/Synch_p2p/p2p.c
@@ -188,6 +188,8 @@ int main(int argc, char ** argv)
 
   vector = (double *) malloc(total_length*sizeof(double));
   MPI_Win_create(vector, total_length*sizeof(double), sizeof(double), rma_winfo, MPI_COMM_WORLD, &rma_win);
+#warning Why are we not using MPI_Win_allocate here?
+#warning If this is a shared-memory bug, then we need to fix the bug.
   /* MPI_Win_allocate(total_length*sizeof(double), sizeof(double), rma_winfo, MPI_COMM_WORLD, (void *) &vector, &rma_win); */
   if (vector == NULL) {
     printf("Could not allocate space for grid slice of %ld by %ld points",
@@ -315,7 +317,7 @@ int main(int argc, char ** argv)
            1.0E-06 * 2 * ((double)((m-1)*(n-1)))/avgtime, avgtime);
   }
 
-  MPI_Win_free(&rma_win);
+  PRK_Win_free(&rma_win);
   MPI_Info_free(&rma_winfo);
 
   MPI_Finalize();

--- a/MPIRMA/Transpose/transpose.c
+++ b/MPIRMA/Transpose/transpose.c
@@ -287,7 +287,7 @@ int main(int argc, char ** argv)
     }
     bail_out(error);
  
-    MPI_Win_allocate (Block_size*(Num_procs-1)*sizeof(double), sizeof(double), 
+    PRK_Win_allocate (Block_size*(Num_procs-1)*sizeof(double), sizeof(double), 
                       rma_winfo, MPI_COMM_WORLD, &Work_in_p, &rma_win);
     if (Work_in_p == NULL){
       printf(" Error allocating space for work on node %d\n",my_ID);
@@ -454,7 +454,7 @@ int main(int argc, char ** argv)
       MPI_Win_unlock_all(rma_win);
     }
 #endif
-    MPI_Win_free(&rma_win);
+    PRK_Win_free(&rma_win);
   }
  
   MPI_Finalize();

--- a/MPIRMA/Transpose/transpose.c
+++ b/MPIRMA/Transpose/transpose.c
@@ -160,9 +160,11 @@ int main(int argc, char ** argv)
          avgtime;
   MPI_Win  rma_win = MPI_WIN_NULL;
   MPI_Info rma_winfo = MPI_INFO_NULL;
-  int passive_target = 0,  /* use passive target RMA sync           */
-      flush_local = 1,     /* flush local (or remote) after put     */
-      flush_bundle = 1;    /* flush every <bundle> put calls        */
+  int passive_target = 0;  /* use passive target RMA sync           */
+#if MPI_VERSION >= 3
+  int  flush_local  = 1;   /* flush local (or remote) after put     */
+  int  flush_bundle = 1;   /* flush every <bundle> put calls        */
+#endif
  
 /*********************************************************************
 ** Initialize the MPI environment
@@ -205,8 +207,10 @@ int main(int argc, char ** argv)
  
     if (argc >= 4) Tile_order     = atoi(*++argv);
     if (argc >= 5) passive_target = atoi(*++argv);
+#if MPI_VERSION >= 3
     if (argc >= 6) flush_local    = atoi(*++argv);
     if (argc >= 7) flush_bundle   = atoi(*++argv);
+#endif
  
     ENDOFTESTS:;
   }
@@ -220,7 +224,11 @@ int main(int argc, char ** argv)
           printf("Tile size            = %d\n", Tile_order);
     else  printf("Untiled\n");
     if (passive_target) {
+#if MPI_VERSION < 3
+        printf("Synchronization      = MPI_Win_(un)lock\n");
+#else
         printf("Synchronization      = MPI_Win_flush%s (bundle=%d)\n", flush_local ? "_local" : "", flush_bundle);
+#endif
     } else {
         printf("Synchronization      = MPI_Win_fence\n");
     }
@@ -231,8 +239,10 @@ int main(int argc, char ** argv)
   MPI_Bcast (&iterations,     1, MPI_INT,  root, MPI_COMM_WORLD);
   MPI_Bcast (&Tile_order,     1, MPI_INT,  root, MPI_COMM_WORLD);
   MPI_Bcast (&passive_target, 1, MPI_INT,  root, MPI_COMM_WORLD);
+#if MPI_VERSION >= 3
   MPI_Bcast (&flush_local,    1, MPI_INT,  root, MPI_COMM_WORLD);
   MPI_Bcast (&flush_bundle,   1, MPI_INT,  root, MPI_COMM_WORLD);
+#endif
  
   /* a non-positive tile size means no tiling of the local transpose */
   tiling = (Tile_order > 0) && (Tile_order < order);
@@ -286,9 +296,11 @@ int main(int argc, char ** argv)
     bail_out(error);
   }
 
+#if MPI_VERSION >= 3
   if (passive_target && Num_procs>1) {
     MPI_Win_lock_all(MPI_MODE_NOCHECK,rma_win);
   }
+#endif
   
   /* Fill the original column matrix                                                */
   istart = 0;  
@@ -351,11 +363,19 @@ int main(int argc, char ** argv)
 		A(it,jt) += 1.0;
               }
       }
- 
+
+#if MPI_VERSION < 3
+      if (passive_target) {
+          MPI_Win_lock(MPI_LOCK_SHARED, send_to, MPI_MODE_NOCHECK, rma_win);
+      }
+#endif
       MPI_Put(Work_out_p+Block_size*(phase-1), Block_size, MPI_DOUBLE, send_to, 
               Block_size*(phase-1), Block_size, MPI_DOUBLE, rma_win); 
 
       if (passive_target) {
+#if MPI_VERSION < 3
+        MPI_Win_unlock(send_to, rma_win);
+#else
         if (flush_bundle==1) {
             if (flush_local==1) {
                 MPI_Win_flush_local(send_to, rma_win);
@@ -370,11 +390,14 @@ int main(int argc, char ** argv)
                 MPI_Win_flush_all(rma_win);
             }
         }
+#endif
       }
     }  /* end of phase loop for puts  */
     if (Num_procs>1) {
       if (passive_target) {
+#if MPI_VERSION >= 3
           MPI_Win_flush_all(rma_win);
+#endif
           MPI_Barrier(MPI_COMM_WORLD);
       } else {
           MPI_Win_fence (MPI_MODE_NOSUCCEED, rma_win);
@@ -426,9 +449,11 @@ int main(int argc, char ** argv)
   bail_out(error);
 
   if (rma_win!=MPI_WIN_NULL) {
+#if MPI_VERSION >=3
     if (passive_target) {
       MPI_Win_unlock_all(rma_win);
     }
+#endif
     MPI_Win_free(&rma_win);
   }
  

--- a/include/par-res-kern_mpi.h
+++ b/include/par-res-kern_mpi.h
@@ -41,5 +41,51 @@ POSSIBILITY OF SUCH DAMAGE.
                 ( level==MPI_THREAD_FUNNELED ? "THREAD_FUNNELED" : \
                     ( level==MPI_THREAD_SINGLE ? "THREAD_SINGLE" : "THREAD_UNKNOWN" ) ) ) )
 
+/* We should set an attribute that indicates we need to free memory
+ * when using this so that the MPI_Win_free does not create a
+ * double-free situation when paired with a real MPI_Win_create call. */
+int PRK_Win_allocate(MPI_Aint size, int disp_unit, MPI_Info info, 
+                     MPI_Comm comm, void * baseptr, MPI_Win * win)
+{
+#if MPI_VERSION < 3 
+    int rc = MPI_SUCCESS;
+    MPI_Info alloc_info = MPI_INFO_NULL;
+    MPI_Info win_info = MPI_INFO_NULL;
+    rc = MPI_Alloc_mem(size, alloc_info, &baseptr);
+    if (rc!=MPI_SUCCESS) MPI_Abort(rc,MPI_COMM_WORLD);
+    rc = MPI_Win_create(baseptr, size, disp_unit, win_info, comm, win);
+    if (rc!=MPI_SUCCESS) MPI_Abort(rc,MPI_COMM_WORLD);
+    return MPI_SUCCESS;
+#else
+    return MPI_Win_allocate(size, disp_unit, info, comm, baseptr, win);
+#endif
+}
+
+int PRK_Win_free(MPI_Win * win)
+{
+#if MPI_VERSION < 3 
+    int rc = MPI_SUCCESS;
+    int flag = 0;
+    void * attr_ptr;
+    rc = MPI_Win_get_attr(*win, MPI_WIN_BASE, (void*)&attr_ptr, &flag);
+    if (rc!=MPI_SUCCESS) MPI_Abort(rc,MPI_COMM_WORLD);
+    /* We do not check for the case of size=0 here,
+     * but it may be worth adding in the future. */
+    if (flag) {
+        void * baseptr = (void*)attr_ptr;
+        rc = MPI_Free_mem(baseptr);
+        if (rc!=MPI_SUCCESS) MPI_Abort(rc,MPI_COMM_WORLD);
+    } else {
+        int rank;
+        MPI_Comm_rank(MPI_COMM_WORLD,&rank);
+        printf("%d: could not capture baseptr from win attribute: memory leak.\n",rank);
+    }
+    rc = MPI_Win_free(win);
+    if (rc!=MPI_SUCCESS) MPI_Abort(rc,MPI_COMM_WORLD);
+    return MPI_SUCCESS;
+#else
+    return MPI_Win_free(win);
+#endif
+}
 
 extern void bail_out(int);

--- a/include/par-res-kern_mpi.h
+++ b/include/par-res-kern_mpi.h
@@ -69,8 +69,10 @@ int PRK_Win_free(MPI_Win * win)
 #if MPI_VERSION < 3
     int flag = 0;
     void * attr_ptr;
+#ifndef ADAPTIVE_MPI
     rc = MPI_Win_get_attr(*win, MPI_WIN_BASE, (void*)&attr_ptr, &flag);
     if (rc!=MPI_SUCCESS) MPI_Abort(rc,MPI_COMM_WORLD);
+#endif
     /* We do not check for the case of size=0 here,
      * but it may be worth adding in the future. */
     if (flag) {
@@ -91,15 +93,19 @@ int PRK_Win_free(MPI_Win * win)
     /* See if window was created with MPI_Win_create... */
     int flag = 0;
     void * attr_ptr;
+#ifndef ADAPTIVE_MPI
     rc = MPI_Win_get_attr(*win, MPI_WIN_CREATE_FLAVOR, (void*)&attr_ptr, &flag);
     if (rc!=MPI_SUCCESS) MPI_Abort(rc,MPI_COMM_WORLD);
+#endif
     if (flag) {
         int * flavor = (int*)attr_ptr;
         /* ...if it was, determine the base address of the user buffer... */
         if (*flavor==MPI_WIN_FLAVOR_CREATE) {
             flag = 0;
+#ifndef ADAPTIVE_MPI
             rc = MPI_Win_get_attr(*win, MPI_WIN_BASE, (void*)&attr_ptr, &flag);
             if (rc!=MPI_SUCCESS) MPI_Abort(rc,MPI_COMM_WORLD);
+#endif
             /* ...and free the base address. */
             if (flag) {
                 baseptr = attr_ptr;


### PR DESCRIPTION
When we only have MPI-2, we need to work around the lack of MPI lock_all, flush, and win_allocate.