### PR TITLE
Travis ci mpichorg failover

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,7 +134,8 @@ env:
   - PRK_TARGET=allserial
 before_install:
   - pwd
-  - export TRAVIS_ROOT=$HOME/PRK-deps
+  - export TRAVIS_HOME=$PWD
+  - export TRAVIS_ROOT=$TRAVIS_HOME/PRK-deps
   - mkdir -p $TRAVIS_ROOT
 install:
   - export PATH=$TRAVIS_ROOT/bin:$PATH

--- a/travis/install-mpi.sh
+++ b/travis/install-mpi.sh
@@ -26,7 +26,6 @@ case "$os" in
                 ;;
         esac
         ;;
-
     Linux)
         echo "Linux"
         case "$CC" in
@@ -64,7 +63,6 @@ case "$os" in
                 ;;
         esac
         case "$MPI_IMPL" in
-            cd $TRAVIS_ROOT
             mpich)
                 if [ ! -d "$TRAVIS_ROOT/mpich" ]; then
                     set +e
@@ -78,7 +76,7 @@ case "$os" in
                              -O mpich-3.2.tar.gz
                         tar -xzf mpich-3.2.tar.gz
                         cd mpich-3.2
-                        sh $TRAVIS_HOME/travis/install-autotools.sh
+                        sh $TRAVIS_HOME/travis/install-autotools.sh $TRAVIS_ROOT
                         ./autogen.sh
                     else
                         tar -xzf mpich-3.2.tar.gz

--- a/travis/install-mpi.sh
+++ b/travis/install-mpi.sh
@@ -64,11 +64,26 @@ case "$os" in
                 ;;
         esac
         case "$MPI_IMPL" in
+            cd $TRAVIS_ROOT
             mpich)
                 if [ ! -d "$TRAVIS_ROOT/mpich" ]; then
-                    wget --no-check-certificate -q http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz
-                    tar -xzf mpich-3.2.tar.gz
-                    cd mpich-3.2
+                    set +e
+                    wget --no-check-certificate -q \
+                         http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz
+                    set -e
+                    if [ ! -f "$TRAVIS_ROOT/mpich-3.2.tar.gz" ]; then
+                        echo "MPICH download from mpich.org failed - trying Github mirror"
+                        wget --no-check-certificate -q \
+                             https://github.com/jeffhammond/mpich/archive/v3.2.tar.gz \
+                             -O mpich-3.2.tar.gz
+                        tar -xzf mpich-3.2.tar.gz
+                        cd mpich-3.2
+                        sh $TRAVIS_HOME/travis/install-autotools.sh
+                        ./autogen.sh
+                    else
+                        tar -xzf mpich-3.2.tar.gz
+                        cd mpich-3.2
+                    fi
                     mkdir build && cd build
                     ../configure CC=$PRK_CC CXX=$PRK_CXX --disable-fortran --prefix=$TRAVIS_ROOT/mpich
                     make -j4


### PR DESCRIPTION
This does not address the Hydra-only download required for Sandia OpenSHMEM, just the MPICH 3.2 failures.