### PR TITLE
Add -lm back to Stencil LIBS

### DIFF
--- a/SHMEM/Stencil/Makefile
+++ b/SHMEM/Stencil/Makefile
@@ -11,7 +11,7 @@ USERFLAGS    =
 
 #set the following variables for custom libraries and/or other objects
 EXTOBJS      = 
-LIBS         =
+LIBS         = -lm
 LIBPATHS     = 
 INCLUDEPATHS = 
 


### PR DESCRIPTION
Stencil has a dependence on libm, so it should be included in LIBS in
the stencil makefile.  This was removed in error in ac5bf13ea.

Signed-off-by: James Dinan <james.dinan@intel.com>