### PR TITLE
SHMEM collectives are one-sided

### DIFF
--- a/SHMEM/Stencil/stencil.c
+++ b/SHMEM/Stencil/stencil.c
@@ -275,9 +275,8 @@ int main(int argc, char ** argv) {
     printf("Number of iterations   = %d\n", iterations);
   }
 
-  shmem_barrier_all();
- 
   shmem_broadcast32(&arguments[0], &arguments[0], 2, root, 0, 0, Num_procs, pSync_bcast);
+  shmem_barrier_all();
 
   iterations=arguments[0];
   n=arguments[1];

--- a/SHMEM/Transpose/transpose.c
+++ b/SHMEM/Transpose/transpose.c
@@ -232,11 +232,10 @@ int main(int argc, char ** argv)
           printf("Tile size            = %d\n", Tile_order);
     else  printf("Untiled\n");
   }
-  
-  shmem_barrier_all();
 
   /*  Broadcast input data to all ranks */
   shmem_broadcast32(&arguments[0], &arguments[0], 3, root, 0, 0, Num_procs, pSync_bcast);
+  shmem_barrier_all();
 
   iterations=arguments[0];
   order=arguments[1];


### PR DESCRIPTION
shmem_broadcast* behaves like shmem_put and thus requires SHMEM
synchronization operations to complete remotely.  for our purposes
shmem_barrier_all is good for this.