### PR TITLE
Cleanup warnings in synch_p2p code

### DIFF
--- a/SHMEM/Synch_p2p/p2p.c
+++ b/SHMEM/Synch_p2p/p2p.c
@@ -136,7 +136,7 @@ int main(int argc, char ** argv)
   n = atol(*++argv);
   if (m < 1 || n < 1){
     if (my_ID == root)
-      printf("ERROR: grid dimensions must be positive: %d, %d \n", m, n);
+      printf("ERROR: grid dimensions must be positive: %ld, %ld \n", m, n);
     error = 1;
     goto ENDOFTESTS;
   }
@@ -155,7 +155,7 @@ int main(int argc, char ** argv)
 
   if (m<=Num_procs) {
     if (my_ID == root)
-      printf("ERROR: First grid dimension %d must be > #ranks %ld\n", m, Num_procs);
+      printf("ERROR: First grid dimension %ld must be > #ranks %d\n", m, Num_procs);
     error = 1;
   }
   ENDOFTESTS:;

--- a/include/par-res-kern_general.h
+++ b/include/par-res-kern_general.h
@@ -132,7 +132,9 @@ static inline void* prk_malloc(size_t bytes)
     return prk_malloc(bytes);
 #else /* if defined(PRK_USE_POSIX_MEMALIGN) */
     void * ptr = NULL;
-    posix_memalign(&ptr,alignment,bytes);
+    int ret;
+    ret = posix_memalign(&ptr,alignment,bytes);
+    if (ret) ptr = NULL;
     return ptr;
 #endif
 }


### PR DESCRIPTION
```
cd SHMEM/Synch_p2p;         make p2p       "DEFAULT_OPT_FLAGS   = -O3"
make[1]: Entering directory `/home/travis/travis/src/PRK/SHMEM/Synch_p2p'
oshcc -O3 -DSHMEM     -I../../include -c p2p.c
p2p.c: In function ‘main’:
p2p.c:139:7: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘long int’ [-Wformat]
p2p.c:139:7: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘long int’ [-Wformat]
p2p.c:158:7: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘long int’ [-Wformat]
p2p.c:158:7: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘int’ [-Wformat]
p2p.c: In function ‘prk_malloc’:
../../include/par-res-kern_general.h:135:19: warning: ignoring return value of ‘posix_memalign’, declared with attribute warn_unused_result [-Wunused-result]
```