### PR TITLE
Add RTR flags to fix sync race in PRK Transpose

### DIFF
--- a/SHMEM/Transpose/Makefile
+++ b/SHMEM/Transpose/Makefile
@@ -1,28 +1,43 @@
 include ../../common/SHMEM.defs
+
 ##### User configurable options #####
-
-OPTFLAGS    = $(DEFAULT_OPT_FLAGS)
-#description: change above into something that is a decent optimization on you system
-
 #uncomment any of the following flags (and change values) to change defaults
 
-DEBUGFLAG    =  -DVERBOSE
-#description: default diagnostic style is silent
+OPTFLAGS    = $(DEFAULT_OPT_FLAGS) 
+#description: change above into something that is a decent optimization on you system
 
-USERFLAGS     =
+USERFLAGS    = 
 #description: parameter to specify optional flags
 
 #set the following variables for custom libraries and/or other objects
-
-EXTOBJS      =
-LIBS         = -lm
-LIBPATHS     =
-INCLUDEPATHS =
+EXTOBJS      = 
+LIBS         = 
+LIBPATHS     = 
+INCLUDEPATHS = 
 
 ### End User configurable options ###
 
-TUNEFLAGS   = $(DEBUGFLAG) $(USERFLAGS)
+ifndef BARRIER_SYNCH
+  BARRIER_SYNCH=0
+endif
+#description: default is not to use a barrier but point to point synchronization
+
+ifndef VERBOSE
+  VERBOSE=0
+endif
+#description: default diagnostic style is silent
+
+VERBOSEFLAG     = -DVERBOSE=$(VERBOSE)
+SYNCHFLAG       = -DBARRIER_SYNCH=$(BARRIER_SYNCH)
+
+OPTIONSSTRING="Make options:\n\
+OPTION                  MEANING                             DEFAULT\n\
+BARRIER_SYNCH=0/1  use point-to-point/barrier synchronization [0]  \n\
+VERBOSE=0/1        omit/include verbose run information       [0]"
+
+TUNEFLAGS    = $(VERBOSEFLAG)  $(SYNCHFLAG)
 PROGRAM     = transpose
 OBJS        = $(PROGRAM).o $(COMOBJS)
 
 include ../../common/make.common
+

--- a/SHMEM/Transpose/transpose.c
+++ b/SHMEM/Transpose/transpose.c
@@ -380,7 +380,7 @@ int main(int argc, char ** argv)
           B(i,j) += Work_in(phase, i,j);
 
       /* Tell sender that we are ready to for the next iteration */
-      shmem_int_inc(&send_flag[my_ID], recv_from);
+      shmem_int_p(&send_flag[my_ID], 1, recv_from);
     }  /* end of phase loop  */
   } /* end of iterations */
 


### PR DESCRIPTION
Fix a race in the iterations loop where iterations can overlap resulting in data corruption and deadlock.  The fix adds another set of flags to inform the sender that the receiver is ready to receive the message.

Note: this fix will have a negative impact on performance of the flag update is blocking in the SHMEM library.