### PR TITLE
match preprocessor logic for _mm_{malloc,free}

### DIFF
--- a/include/par-res-kern_general.h
+++ b/include/par-res-kern_general.h
@@ -142,7 +142,7 @@ static inline void* prk_malloc(size_t bytes)
 
 static inline void prk_free(void* p)
 {
-#if defined(__INTEL_COMPILER) && !defined(PRK_USE_POSIX_MEMALIGN)
+#if !defined(__UPC__) && defined(__INTEL_COMPILER) && !defined(PRK_USE_POSIX_MEMALIGN)
     _mm_free(p);
 #else
     free(p);


### PR DESCRIPTION
_mm_malloc depended on UPC, but _mm_free did not.
this could lead to failures in free.