### PR TITLE
add make.defs example for PGI compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ifndef matrix_rank
 endif
 
 ifndef PRK_FLAGS
-  PRK_FLAGS=-O3 -std=c99
+  PRK_FLAGS=-O3
 endif
 
 default: allserial allopenmp allmpi

--- a/common/make.defs.pgi
+++ b/common/make.defs.pgi
@@ -1,0 +1,19 @@
+#
+# This file shows the PGI toolchain options for PRKs.
+#
+# Base compilers and language options
+#
+# C99 is required in some implementations.
+CC=pgcc -c11
+# All of the Fortran code is written for the 2008 standard and requires preprocessing.
+FC=pgfortran -Mpreprocess
+# C++11 may not be required but does no harm here.
+CXX=pgc++ --c++11
+#
+# Compiler flags
+#
+DEFAULT_OPT_FLAGS=-O2
+#
+# OpenMP flags
+#
+OPENMPFLAG=-mp


### PR DESCRIPTION
- PGI fine for serial (C)
- PGI fine for OpenMP (C)
- PGI not fine for Fortran except OpenMP (see https://github.com/ParRes/Kernels/issues/140 for details)