### PR TITLE
disable coarrays when PGI is used

### DIFF
--- a/FORTRAN/Stencil/stencil-coarray.f90
+++ b/FORTRAN/Stencil/stencil-coarray.f90
@@ -62,6 +62,15 @@
 !            Izaak "Zaak" Beekman, March 2017
 ! *************************************************************************
 
+#if defined(__PGI) || defined(__llvm__)
+
+program main
+    print*,'PGI does not support Fortran 2008'
+    stop 1
+end program main
+
+#else
+
 function prk_get_wtime() result(t)
   use iso_fortran_env
   real(kind=REAL64) ::  t
@@ -476,3 +485,5 @@ program main
   endif
 
 end program main
+
+#endif

--- a/FORTRAN/Synch_p2p/p2p-coarray.f90
+++ b/FORTRAN/Synch_p2p/p2p-coarray.f90
@@ -56,6 +56,15 @@
 !          - Minor bug fixes by Izaak "Zaak" Beekman, March 2017
 ! ********************************************************************
 
+#if defined(__PGI) || defined(__llvm__)
+
+program main
+    print*,'PGI does not support Fortran 2008'
+    stop 1
+end program main
+
+#else
+
 function prk_get_wtime() result(t)
   use iso_fortran_env
   real(kind=REAL64) ::  t
@@ -235,3 +244,5 @@ program main
                ! https://github.com/sourceryinstitute/OpenCoarrays/issues/309
 
 end program
+
+#endif

--- a/FORTRAN/Transpose/transpose-coarray.f90
+++ b/FORTRAN/Transpose/transpose-coarray.f90
@@ -53,6 +53,15 @@
 !          Izaak "Zaak" Beekman
 ! *******************************************************************
 
+#if defined(__PGI) || defined(__llvm__)
+
+program main
+    print*,'PGI does not support Fortran 2008'
+    stop 1
+end program main
+
+#else
+
 function prk_get_wtime() result(t)
   use iso_fortran_env
   real(kind=REAL64) ::  t
@@ -322,3 +331,4 @@ program main
 
 end program main
 
+#endif


### PR DESCRIPTION
yes, this has the negative effect of allowing builds to succeed when
programs will fail at runtime, but i prefer that in the PRK project.