### PR TITLE
consolidate Fortran testing in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,7 @@ env:
   - PRK_TARGET=alljulia
   - PRK_TARGET=allrust
   - PRK_TARGET=allopenmp
-  - PRK_TARGET=allfortranserial
-  - PRK_TARGET=allfortranopenmp
-  - PRK_TARGET=allfortrantarget
-  - PRK_TARGET=allfortranpretty
-  - PRK_TARGET=allfortrancoarray
+  - PRK_TARGET=allfortran
   - PRK_TARGET=allmpi1
   - PRK_TARGET=allmpirma
   - PRK_TARGET=allmpishm
@@ -105,15 +101,7 @@ matrix:
     env: PRK_TARGET=allhpx3
   # LLVM Fortran is not ready.
   - compiler: clang
-    env: PRK_TARGET=allfortranserial
-  - compiler: clang
-    env: PRK_TARGET=allfortranopenmp
-  - compiler: clang
-    env: PRK_TARGET=allfortrantarget
-  - compiler: clang
-    env: PRK_TARGET=allfortranpretty
-  - compiler: clang
-    env: PRK_TARGET=allfortrancoarray
+    env: PRK_TARGET=allfortran
   # Skip Linux because we rely on Homebrew for these
   - os: linux
     env: PRK_TARGET=alloctave
@@ -170,10 +158,6 @@ matrix:
     env: PRK_TARGET=allfgmpi
   - os: linux
     env: PRK_TARGET=allfgmpi
-  # Linux may not have GCC-6...
-  #- os: linux
-  #  compiler: gcc
-  #  env: PRK_TARGET=allfortrancoarray
   # BUPC has trouble with flags
   #- os: linux
   #  env: PRK_TARGET=allupc UPC_IMPL=bupc GASNET_CONDUIT=mpi PRK_FLAGS="-Wc,-O3"

--- a/FORTRAN/Makefile
+++ b/FORTRAN/Makefile
@@ -1,4 +1,8 @@
-include ../common/FORTRAN.defs
+include ../common/make.defs
+
+ifndef CAFC
+  CAFC=$(FC)
+endif
 
 ifndef RADIUS
   RADIUS=2
@@ -59,7 +63,7 @@ p2p-openmp-datapar: p2p-openmp-datapar.f90
 	$(FC) $(FCFLAGS) $(OPENMPFLAG) $< -o $@
 
 %-coarray: %-coarray.f90
-	$(CAFCOMPILER) $(FCFLAGS) $< $(COARRAYFLAG) -o $@
+	$(CAFC) $(FCFLAGS) $< $(COARRAYFLAG) -o $@
 
 %-target: %-target.f90
 	$(FC) $(FCFLAGS) $(OPENMPFLAG) $(OFFLOADFLAG) $< -o $@

--- a/common/FORTRAN.defs
+++ b/common/FORTRAN.defs
@@ -1,7 +1,0 @@
-include ../common/make.defs
-ifeq ($(MPIF90),)
-    CAFCOMPILER=$(FC)
-else
-    CAFCOMPILER=$(MPIF90)
-endif
-PROG_ENV=-DCAF

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -513,7 +513,7 @@ case "$PRK_TARGET" in
                 elif [ "${TRAVIS_OS_NAME}" = "linux" ] ; then
                     export PRK_CAFC=$TRAVIS_ROOT/opencoarrays/bin/caf
                 fi
-                echo "CAFC=$PRK_CAFC" >> common/make.defs
+                echo "CAFC=$PRK_CAFC -std=f2008 -cpp" >> common/make.defs
                 echo "COARRAYFLAG=-fcoarray=single" >> common/make.defs
                 ;;
             clang)

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -487,13 +487,10 @@ case "$PRK_TARGET" in
             done
         done
         ;;
-    allfortran*)
-        # allfortranserial allfortranopenmp allfortrancoarray allfortranpretty allfortrantarget
+    allfortran)
         echo "Fortran"
+        export PRK_TARGET_PATH=FORTRAN
         case "$CC" in
-            icc)
-                echo "FC=ifort" >> common/make.defs
-                ;;
             gcc)
                 for major in "-9" "-8" "-7" "-6" "-5" "-4" "-3" "-2" "-1" "" ; do
                     if [ -f "`which gfortran$major`" ]; then
@@ -506,114 +503,93 @@ case "$PRK_TARGET" in
                     echo "No Fortran compiler found!"
                     exit 9
                 fi
+                export PRK_FC="$PRK_FC -std=f2008 -cpp"
+                echo "FC=$PRK_FC" >> common/make.defs
+                echo "OPENMPFLAG=-fopenmp" >> common/make.defs
+                echo "OFFLOADFLAG=-foffload=\"-O3 -v\"" >> common/make.defs
+                if [ "${TRAVIS_OS_NAME}" = "osx" ] ; then
+                    # Homebrew installs a symlink in /usr/local/bin
+                    export PRK_CAFC=caf
+                elif [ "${TRAVIS_OS_NAME}" = "linux" ] ; then
+                    export PRK_CAFC=$TRAVIS_ROOT/opencoarrays/bin/caf
+                fi
+                echo "CAFC=$PRK_CAFC" >> common/make.defs
+                echo "COARRAYFLAG=-fcoarray=single" >> common/make.defs
                 ;;
             clang)
                 echo "LLVM Fortran is not supported."
                 exit 9
                 echo "FC=flang" >> common/make.defs
                 ;;
-        esac
-        case "$PRK_TARGET" in
-            allfortrancoarray)
-                # OpenCoarrays uses Open-MPI on Mac thanks to Homebrew
-                # see https://github.com/open-mpi/ompi/issues/2956
-                export TMPDIR=/tmp
-                if [ "${CC}" = "gcc" ] ; then
-                    #echo "FC=$PRK_FC\nCOARRAYFLAG=-fcoarray=single" >> common/make.defs
-                    if [ "${TRAVIS_OS_NAME}" = "osx" ] ; then
-                        # Homebrew installs a symlink in /usr/local/bin
-                        export PRK_CAFC=caf
-                    elif [ "${TRAVIS_OS_NAME}" = "linux" ] ; then
-                        export PRK_CAFC=$TRAVIS_ROOT/opencoarrays/bin/caf
-                    fi
-                    echo "FC=$PRK_CAFC\nCOARRAYFLAG=-cpp -std=f2008 -fcoarray=lib" >> common/make.defs
-                elif [ "${CC}" = "icc" ] ; then
-                    export PRK_CAFC="ifort"
-                    echo "FC=$PRK_CAFC\nCOARRAYFLAG=-fpp -std08 -traceback -coarray" >> common/make.defs
-                fi
-                ;;
-            allfortrantarget)
-                if [ "${CC}" = "gcc" ] ; then
-                    export PRK_FC="$PRK_FC -std=f2008 -cpp"
-                    echo "FC=$PRK_FC\nOPENMPFLAG=-fopenmp\nOFFLOADFLAG=-foffload=\"-O3 -v\"" >> common/make.defs
-                elif [ "${CC}" = "icc" ] ; then
-                    if [ "${TRAVIS_OS_NAME}" = "linux" ] ; then
-                        echo "ICC does not support OpenMP target on MacOS yet..."
-                        exit 7
-                    fi
-                    export PRK_FC="ifort -fpp -std08"
-                    echo "FC=$PRK_FC\nOPENMPFLAG=-qopenmp\nOFFLOADFLAG=-qopenmp-offload=host" >> common/make.defs
-                fi
-                ;;
-            *)
-                if [ "${CC}" = "gcc" ] ; then
-                    export PRK_FC="$PRK_FC -std=f2008 -cpp"
-                    echo "FC=$PRK_FC\nOPENMPFLAG=-fopenmp" >> common/make.defs
-                elif [ "${CC}" = "icc" ] ; then
-                    # -heap-arrays prevents SEGV in transpose-pretty (?)
-                    export PRK_FC="ifort -fpp -std08 -traceback -heap-arrays"
-                    echo "FC=$PRK_FC\nOPENMPFLAG=-qopenmp" >> common/make.defs
-                fi
+            icc)
+                # -heap-arrays prevents SEGV in transpose-pretty (?)
+                export PRK_FC="ifort -fpp -std08 -heap-arrays"
+                echo "FC=$PRK_FC" >> common/make.defs
+                echo "OPENMPFLAG=-qopenmp" >> common/make.defs
+                echo "OFFLOADFLAG=-qopenmp-offload=host" >> common/make.defs
+                echo "COARRAYFLAG=-coarray" >> common/make.defs
                 ;;
         esac
-        #make $PRK_TARGET # see below
-        export PRK_TARGET_PATH=FORTRAN
-        case "$PRK_TARGET" in
-            allfortranserial)
-                make -C ${PRK_TARGET_PATH} serial
-                $PRK_TARGET_PATH/p2p               10 1024 1024
-                $PRK_TARGET_PATH/stencil           10 1000
-                $PRK_TARGET_PATH/transpose         10 1024 1
-                $PRK_TARGET_PATH/transpose         10 1024 32
-                ;;
-            allfortranpretty)
-                make -C ${PRK_TARGET_PATH} pretty
-                #$PRK_TARGET_PATH/p2p-pretty          10 1024 1024
-                # pretty versions do not support tiling...
-                $PRK_TARGET_PATH/stencil-pretty      10 1000
-                $PRK_TARGET_PATH/transpose-pretty    10 1024
-                ;;
-            allfortranopenmp)
-                make -C ${PRK_TARGET_PATH} p2p-openmp-tasks p2p-openmp-datapar stencil-openmp transpose-openmp
-                export OMP_NUM_THREADS=2
-                $PRK_TARGET_PATH/p2p-openmp-tasks     10 1024 1024
-                $PRK_TARGET_PATH/p2p-openmp-datapar   10 1024 1024
-                #$PRK_TARGET_PATH/p2p-openmp-doacross  10 1024 1024 # most compilers do not support doacross yet
-                $PRK_TARGET_PATH/stencil-openmp       10 1000
-                $PRK_TARGET_PATH/transpose-openmp     10 1024 1
-                $PRK_TARGET_PATH/transpose-openmp     10 1024 32
-                ;;
-            allfortrantarget)
-                make -C ${PRK_TARGET_PATH} stencil-openmp-target transpose-openmp-target
-                export OMP_NUM_THREADS=2
-                #$PRK_TARGET_PATH/p2p-openmp-target           10 1024 1024 # most compilers do not support doacross yet
-                $PRK_TARGET_PATH/stencil-openmp-target       10 1000
-                $PRK_TARGET_PATH/transpose-openmp-target     10 1024 1
-                $PRK_TARGET_PATH/transpose-openmp-target     10 1024 32
-                ;;
-            allfortrancoarray)
-                make -C ${PRK_TARGET_PATH} coarray
-                export PRK_MPI_PROCS=4
-                if [ "${CC}" = "gcc" ] ; then
-                    if [ "${TRAVIS_OS_NAME}" = "osx" ] ; then
-                        # Homebrew installs a symlink in /usr/local/bin
-                        export PRK_LAUNCHER=cafrun
-                    elif [ "${TRAVIS_OS_NAME}" = "linux" ] ; then
-                        export PRK_LAUNCHER=$TRAVIS_ROOT/opencoarrays/bin/cafrun
-                    fi
-                    $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/p2p-coarray       10 1024 1024
-                    $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/stencil-coarray   10 1000
-                    $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/transpose-coarray 10 1024 1
-                    $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/transpose-coarray 10 1024 32
-                elif [ "${CC}" = "icc" ] ; then
-                    export FOR_COARRAY_NUM_IMAGES=$PRK_MPI_PROCS
-                    $PRK_TARGET_PATH/Synch_p2p/p2p-coarray       10 1024 1024
-                    $PRK_TARGET_PATH/Stencil/stencil-coarray     10 1000
-                    $PRK_TARGET_PATH/Transpose/transpose-coarray 10 1024 1
-                    $PRK_TARGET_PATH/Transpose/transpose-coarray 10 1024 32
+
+        # Serial
+        make -C ${PRK_TARGET_PATH} serial
+        $PRK_TARGET_PATH/p2p               10 1024 1024
+        $PRK_TARGET_PATH/stencil           10 1000
+        $PRK_TARGET_PATH/transpose         10 1024 1
+        $PRK_TARGET_PATH/transpose         10 1024 32
+
+        # Pretty
+        make -C ${PRK_TARGET_PATH} pretty
+        #$PRK_TARGET_PATH/p2p-pretty          10 1024 1024
+        # pretty versions do not support tiling...
+        $PRK_TARGET_PATH/stencil-pretty      10 1000
+        $PRK_TARGET_PATH/transpose-pretty    10 1024
+
+        # OpenMP host
+        make -C ${PRK_TARGET_PATH} p2p-openmp-tasks p2p-openmp-datapar stencil-openmp transpose-openmp
+        export OMP_NUM_THREADS=2
+        $PRK_TARGET_PATH/p2p-openmp-tasks     10 1024 1024
+        $PRK_TARGET_PATH/p2p-openmp-datapar   10 1024 1024
+        #$PRK_TARGET_PATH/p2p-openmp-doacross  10 1024 1024 # most compilers do not support doacross yet
+        $PRK_TARGET_PATH/stencil-openmp       10 1000
+        $PRK_TARGET_PATH/transpose-openmp     10 1024 1
+        $PRK_TARGET_PATH/transpose-openmp     10 1024 32
+
+        # Intel Mac does not support OpenMP target or coarrays
+        if [ "${CC}" = "gcc" ] || [ "${TRAVIS_OS_NAME}" = "linux" ] ; then
+            # OpenMP target
+            make -C ${PRK_TARGET_PATH} stencil-openmp-target transpose-openmp-target
+            export OMP_NUM_THREADS=2
+            #$PRK_TARGET_PATH/p2p-openmp-target           10 1024 1024 # most compilers do not support doacross yet
+            $PRK_TARGET_PATH/stencil-openmp-target       10 1000
+            $PRK_TARGET_PATH/transpose-openmp-target     10 1024 1
+            $PRK_TARGET_PATH/transpose-openmp-target     10 1024 32
+
+            # Fortran coarrays
+            make -C ${PRK_TARGET_PATH} coarray
+            export PRK_MPI_PROCS=4
+            if [ "${CC}" = "gcc" ] ; then
+                if [ "${TRAVIS_OS_NAME}" = "osx" ] ; then
+                    # Homebrew installs a symlink in /usr/local/bin
+                    export PRK_LAUNCHER=cafrun
+                    # OpenCoarrays uses Open-MPI on Mac thanks to Homebrew
+                    # see https://github.com/open-mpi/ompi/issues/2956
+                    export TMPDIR=/tmp
+                elif [ "${TRAVIS_OS_NAME}" = "linux" ] ; then
+                    export PRK_LAUNCHER=$TRAVIS_ROOT/opencoarrays/bin/cafrun
                 fi
-                ;;
-            esac
+                $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/p2p-coarray       10 1024 1024
+                $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/stencil-coarray   10 1000
+                $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/transpose-coarray 10 1024 1
+                $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/transpose-coarray 10 1024 32
+            elif [ "${CC}" = "icc" ] ; then
+                export FOR_COARRAY_NUM_IMAGES=$PRK_MPI_PROCS
+                $PRK_TARGET_PATH/Synch_p2p/p2p-coarray       10 1024 1024
+                $PRK_TARGET_PATH/Stencil/stencil-coarray     10 1000
+                $PRK_TARGET_PATH/Transpose/transpose-coarray 10 1024 1
+                $PRK_TARGET_PATH/Transpose/transpose-coarray 10 1024 32
+            fi
+        fi
         ;;
     allopenmp)
         echo "OpenMP"

--- a/travis/install-deps.sh
+++ b/travis/install-deps.sh
@@ -59,13 +59,13 @@ case "$PRK_TARGET" in
         sh ./travis/install-raja.sh $TRAVIS_ROOT
         sh ./travis/install-kokkos.sh $TRAVIS_ROOT
         ;;
-    allfortran*)
+    allfortran)
         echo "Fortran"
         if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CC}" = "gcc" ] ; then
             brew update || true
             brew install gcc || brew upgrade gcc || true
         fi
-        if [ "${PRK_TARGET}" = "allfortrancoarray" ] && [ "${CC}" = "gcc" ] ; then
+        if [ "${CC}" = "gcc" ] ; then
             sh ./travis/install-opencoarrays.sh $TRAVIS_ROOT
         fi
         ;;

--- a/travis/install-gcc.sh
+++ b/travis/install-gcc.sh
@@ -10,9 +10,9 @@ if [ "${CC}" = "gcc" ] || [ "${CXX}" = "g++" ] ; then
     case "$os" in
         Darwin)
             echo "Mac"
-            brew update
+            brew update || true
             # this is 5.3.0 or later
-            brew upgrade gcc || brew install gcc --force-bottle
+            brew upgrade gcc || brew install gcc --force-bottle || true
             ;;
         DisableLinux)
             echo "Linux"


### PR DESCRIPTION
this should save a little bit of time, at the expense of having to
inspect the logs to know what model failed (which we do for C++ and C1z)