### PR TITLE
consolidate MPI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,7 @@ env:
   - PRK_TARGET=allrust
   - PRK_TARGET=allopenmp
   - PRK_TARGET=allfortran
-  - PRK_TARGET=allmpi1
-  - PRK_TARGET=allmpirma
-  - PRK_TARGET=allmpishm
-  - PRK_TARGET=allmpiomp
+  - PRK_TARGET=allmpi
   - PRK_TARGET=allshmem
   - PRK_TARGET=allampi
   - PRK_TARGET=allfgmpi
@@ -56,23 +53,10 @@ matrix:
   - os: linux
     compiler: clang
     env: PRK_TARGET=allopenmp
-  - os: linux
-    compiler: clang
-    env: PRK_TARGET=allmpiomp
-  # Mac/Clang OpenMP broken because Brew no longer supports "clang-omp"
-  - os: osx
-    compiler: clang
-    env: PRK_TARGET=allopenmp
-  - os: osx
-    compiler: clang
-    env: PRK_TARGET=allmpiomp
   # dealing with broken GCC on Mac not worth it here
   - os: osx
     compiler: gcc
     env: PRK_TARGET=allopenmp
-  - os: osx
-    compiler: gcc
-    env: PRK_TARGET=allmpiomp
   # Clang UPC requires source build, which probably takes too long
   - compiler: clang
     env: PRK_TARGET=allupc UPC_IMPL=gupc
@@ -128,11 +112,7 @@ matrix:
     env: PRK_TARGET=allrust
   # MPI implementations of Transpose hang with Intel compilers (why?!?!)
   - compiler: touch ~/use-intel-compilers ; gcc
-    env: PRK_TARGET=allmpi1
-  - compiler: touch ~/use-intel-compilers ; gcc
-    env: PRK_TARGET=allmpiomp
-  - compiler: touch ~/use-intel-compilers ; gcc
-    env: PRK_TARGET=allmpishm
+    env: PRK_TARGET=allmpi
   # UPC over MPICH on Mac hangs - may be async progress issue
   - os: osx
     env: PRK_TARGET=allupc UPC_IMPL=bupc GASNET_CONDUIT=mpi PRK_FLAGS="-Wc,-O3"
@@ -175,16 +155,6 @@ matrix:
   - os: linux
     compiler: clang
     env: PRK_TARGET=allampi
-  # These started failing in June 2017.  Need to debug.
-  - os: linux
-    compiler: clang
-    env: PRK_TARGET=allmpi1
-  - os: linux
-    compiler: clang
-    env: PRK_TARGET=allmpirma
-  - os: linux
-    compiler: clang
-    env: PRK_TARGET=allmpishm
 addons:
   apt:
     sources:

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -621,29 +621,31 @@ case "$PRK_TARGET" in
         fi
         # Inline the Homebrew OpenMP stuff here so versions do not diverge.
         # Note that -cc= likely only works with MPICH.
-        if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CC}" = "clang" ] ; then
-            CLANG_VERSION=3.9
-            brew install llvm@$CLANG_VERSION || brew upgrade llvm@$CLANG_VERSION
-            export PRK_MPICC="${PRK_MPICC} -cc=/usr/local/opt/llvm@${CLANG_VERSION}/bin/clang-${CLANG_VERSION}"
-        elif [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CC}" = "gcc" ] ; then
+        if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CC}" = "gcc" ] ; then
             GCC_VERSION=6
             brew install gcc@$GCC_VERSION || brew upgrade gcc@$GCC_VERSION
             export PRK_MPICC="${PRK_MPICC} -cc=/usr/local/opt/gcc@${GCC_VERSION}/bin/gcc-${GCC_VERSION}"
-        elif [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${CC}" = "clang" ] ; then
-            # According to http://openmp.llvm.org/, we need version 3.8 or later to get OpenMP.
-            for version in "-5" "-4" "-3.9" "-3.8" "" ; do
-              if [ -f "`which ${CC}${version}`" ]; then
-                  export PRK_CC="${CC}${version}"
-                  echo "Found C: $PRK_CC"
-                  break
-              fi
-            done
-            if [ "x$PRK_CC" = "x" ] ; then
-                export PRK_CC="${CC}"
-            fi
-            ${PRK_CC} -v
-            export PRK_MPICC="${PRK_MPICC} -cc=${PRK_CC}"
         fi
+        #if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CC}" = "clang" ] ; then
+        #    CLANG_VERSION=3.9
+        #    brew install llvm@$CLANG_VERSION || brew upgrade llvm@$CLANG_VERSION
+        #    export PRK_MPICC="${PRK_MPICC} -cc=/usr/local/opt/llvm@${CLANG_VERSION}/bin/clang-${CLANG_VERSION}"
+        #fi
+        #if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${CC}" = "clang" ] ; then
+        #    # According to http://openmp.llvm.org/, we need version 3.8 or later to get OpenMP.
+        #    for version in "-5" "-4" "-3.9" "-3.8" "" ; do
+        #      if [ -f "`which ${CC}${version}`" ]; then
+        #          export PRK_CC="${CC}${version}"
+        #          echo "Found C: $PRK_CC"
+        #          break
+        #      fi
+        #    done
+        #    if [ "x$PRK_CC" = "x" ] ; then
+        #        export PRK_CC="${CC}"
+        #    fi
+        #    ${PRK_CC} -v
+        #    export PRK_MPICC="${PRK_MPICC} -cc=${PRK_CC}"
+        #fi
         echo "MPICC=$PRK_MPICC" >> common/make.defs
         echo "OPENMPFLAG=-fopenmp" >> common/make.defs
 
@@ -669,8 +671,8 @@ case "$PRK_TARGET" in
         $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/AMR/amr             10 1000 100 2 2 1 5 HIGH_WATER
         $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/AMR/amr             10 1000 100 2 2 1 5 NO_TALK
 
-        # MPI+OpenMP will not work with older Clang, as we will probably get on Linux
-        if [ "${TRAVIS_OS_NAME}" = "osx" ] || [ "${CC}" = "gcc" ] ; then
+        # MPI+OpenMP is just too much of a pain with Clang right now.
+        if [ "${CC}" = "gcc" ] ; then
             echo "MPI+OpenMP"
             export PRK_TARGET_PATH=MPIOPENMP
             export PRK_MPI_PROCS=2

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -620,9 +620,16 @@ case "$PRK_TARGET" in
         ;;
     allmpi)
         echo "All MPI"
-        # Clang 3.9 should have OpenMP
+        # Inline the Homebrew OpenMP stuff here so versions do not diverge.
+        # Note that -cc= likely only works with MPICH.
         if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CC}" = "clang" ] ; then
-            export PRK_MPICC="${PRK_MPICC} -cc=clang-3.9"
+            CLANG_VERSION=3.9
+            brew install llvm@$CLANG_VERSION || brew upgrade llvm@$CLANG_VERSION
+            export PRK_MPICC="${PRK_MPICC} -cc=/usr/local/opt/llvm@${CLANG_VERSION}/bin/clang-${CLANG_VERSION}"
+        elif [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CC}" = "gcc" ] ; then
+            GCC_VERSION=6
+            brew install gcc@$GCC_VERSION || brew upgrade gcc@$GCC_VERSION
+            export PRK_MPICC="${PRK_MPICC} -cc=/usr/local/opt/gcc@${GCC_VERSION}/bin/gcc-${GCC_VERSION}"
         fi
         echo "MPICC=$PRK_MPICC" >> common/make.defs
         echo "OPENMPFLAG=-fopenmp" >> common/make.defs

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -649,9 +649,9 @@ case "$PRK_TARGET" in
         echo "MPICC=$PRK_MPICC" >> common/make.defs
         echo "OPENMPFLAG=-fopenmp" >> common/make.defs
 
-        make $PRK_TARGET
 
         echo "MPI-1"
+        make allmpi1
         export PRK_TARGET_PATH=MPI1
         export PRK_MPI_PROCS=4
         $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/Synch_p2p/p2p       10 1024 1024
@@ -674,6 +674,7 @@ case "$PRK_TARGET" in
         # MPI+OpenMP is just too much of a pain with Clang right now.
         if [ "${CC}" = "gcc" ] ; then
             echo "MPI+OpenMP"
+            make allmpiomp
             export PRK_TARGET_PATH=MPIOPENMP
             export PRK_MPI_PROCS=2
             export OMP_NUM_THREADS=2
@@ -684,6 +685,7 @@ case "$PRK_TARGET" in
         fi
 
         echo "MPI-RMA"
+        make allmpirma
         export PRK_TARGET_PATH=MPIRMA
         export PRK_MPI_PROCS=4
         $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/Synch_p2p/p2p       10 1024 1024
@@ -691,6 +693,7 @@ case "$PRK_TARGET" in
         $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/Transpose/transpose 10 1024 32
 
         echo "MPI+MPI"
+        make allmpishm
         export PRK_TARGET_PATH=MPISHM
         export PRK_MPI_PROCS=4
         export PRK_MPISHM_RANKS=$(($PRK_MPI_PROCS/2))

--- a/travis/install-deps.sh
+++ b/travis/install-deps.sh
@@ -77,7 +77,6 @@ case "$PRK_TARGET" in
         ;;
     allmpi)
         echo "Traditional MPI"
-        sh ./travis/install-clang.sh $TRAVIS_ROOT 3.9
         # install except when Intel MPI used
         if [ ! -f ~/use-intel-compilers ] ; then
             sh ./travis/install-mpi.sh $TRAVIS_ROOT $MPI_IMPL 0

--- a/travis/install-deps.sh
+++ b/travis/install-deps.sh
@@ -75,12 +75,9 @@ case "$PRK_TARGET" in
             sh ./travis/install-clang.sh $TRAVIS_ROOT omp
         fi
         ;;
-    allmpi*)
-        echo "Any normal MPI"
-        # only install clang-omp when necessary
-        if [ "${PRK_TARGET}" = "allmpiomp" ] ; then
-            sh ./travis/install-clang.sh $TRAVIS_ROOT omp
-        fi
+    allmpi)
+        echo "Traditional MPI"
+        sh ./travis/install-clang.sh $TRAVIS_ROOT 3.9
         # install except when Intel MPI used
         if [ ! -f ~/use-intel-compilers ] ; then
             sh ./travis/install-mpi.sh $TRAVIS_ROOT $MPI_IMPL 0


### PR DESCRIPTION
this will save a lot of time because we have to build MPICH from source
on Linux, which we can now do once instead of four times.