### PR TITLE
use lambdas instead of functors in TBB transpose and stencil

### DIFF
--- a/Cxx11/generate-cxx-stencil.py
+++ b/Cxx11/generate-cxx-stencil.py
@@ -60,15 +60,11 @@ def codegen(src,pattern,stencil_size,radius,W,model):
         src.write('      PRAGMA_SIMD\n')
         src.write('      for (auto j='+str(radius)+'; j<n-'+str(radius)+'; ++j) {\n')
     elif (model=='tbb'):
-        src.write('template <>\n')
-        if pattern=='star':
-            name='Star'
-        elif pattern=='grid':
-            name='Grid'
-        src.write('struct '+name+'<'+str(radius)+'> {\n')
-        src.write('  void operator()( const tbb::blocked_range2d<int>& r ) const {\n')
-        src.write('    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {\n')
-        src.write('      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {\n')
+        src.write('void '+pattern+str(radius)+'(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {\n')
+        src.write('  tbb::blocked_range2d<int> range('+str(radius)+', n-'+str(radius)+', tile_size, '+str(radius)+', n-'+str(radius)+', tile_size);\n')
+        src.write('  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {\n')
+        src.write('    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {\n')
+        src.write('      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {\n')
     elif (model=='kokkos'):
         src.write('void '+pattern+str(radius)+'(const int n, matrix & in, matrix & out) {\n')
         src.write('    Kokkos::parallel_for ( Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>('+str(radius)+',n-'+str(radius)+'), KOKKOS_LAMBDA(const int i) {\n')
@@ -104,19 +100,14 @@ def codegen(src,pattern,stencil_size,radius,W,model):
     elif (model=='kokkos'):
         src.write('       }\n')
         src.write('     });\n')
+    elif (model=='tbb'):
+        src.write('      }\n')
+        src.write('    }\n')
+        src.write('  });\n')
     else:
         src.write('       }\n')
         src.write('     }\n')
-    if (model=='tbb'):
-        src.write('  }\n\n')
-        src.write('    '+name+'(int n, std::vector<double> & in, std::vector<double> & out)\n')
-        src.write('        : n(n), in(in), out(out) { }\n\n')
-        src.write('    int n;\n')
-        src.write('    std::vector<double> & in;\n')
-        src.write('    std::vector<double> & out;\n')
-        src.write('};\n\n')
-    else:
-        src.write('}\n\n')
+    src.write('}\n\n')
 
 def instance(src,model,pattern,r):
 

--- a/Cxx11/stencil-vector-tbb.cc
+++ b/Cxx11/stencil-vector-tbb.cc
@@ -62,86 +62,7 @@
 
 #include "prk_util.h"
 
-// These empty definitions are required for the compiler to understand the specializations.
-template <int>
-struct Star {
-};
-
-template <int>
-struct Grid {
-};
-
 #include "stencil_tbb.hpp"
-
-struct Initialize
-{
-    public:
-        void operator()( const tbb::blocked_range2d<int>& r ) const {
-            for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-                for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
-                    A_[i*n_+j] = static_cast<double>(i+j);
-                    B_[i*n_+j] = 0.0;
-                }
-            }
-        }
-
-        Initialize(int n, std::vector<double> & A, std::vector<double> & B) : n_(n), A_(A), B_(B) { }
-
-    private:
-        int n_;
-        std::vector<double> & A_;
-        std::vector<double> & B_;
-
-};
-
-struct Add
-{
-    public:
-        void operator()( const tbb::blocked_range2d<int>& r ) const {
-            for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-                for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
-                    A_[i*n_+j] += 1.0;
-                }
-            }
-        }
-
-        Add(int n, std::vector<double> & A) : n_(n), A_(A) { }
-
-    private:
-        int n_;
-        std::vector<double> & A_;
-
-};
-
-void ParallelInitialize(int n, int tile_size, std::vector<double> & A, std::vector<double> & B)
-{
-    Initialize i(n, A, B);
-    const tbb::blocked_range2d<int> r(0, n, tile_size, 0, n, tile_size);
-    parallel_for(r,i);
-}
-
-void ParallelAdd(int n, int tile_size, std::vector<double> & A)
-{
-    Add a(n, A);
-    const tbb::blocked_range2d<int> r(0, n, tile_size, 0, n, tile_size);
-    parallel_for(r,a);
-}
-
-template <int radius>
-void ParallelStar(int n, int tile_size, std::vector<double> & A, std::vector<double> & B)
-{
-    Star<radius> s(n, A, B);
-    const tbb::blocked_range2d<int> r(radius, n-radius, tile_size, radius, n-radius, tile_size);
-    parallel_for(r,s);
-}
-
-template <int radius>
-void ParallelGrid(int n, int tile_size, std::vector<double> & A, std::vector<double> & B)
-{
-    Grid<radius> s(n, A, B);
-    const tbb::blocked_range2d<int> r(radius, n-radius, tile_size, radius, n-radius, tile_size);
-    parallel_for(r,s);
-}
 
 int main(int argc, char * argv[])
 {
@@ -223,7 +144,17 @@ int main(int argc, char * argv[])
 
   auto stencil_time = 0.0;
 
-  ParallelInitialize(n, tile_size, A, B);
+  tbb::blocked_range2d<int> range(0, n, tile_size, 0, n, tile_size);
+  tbb::parallel_for( range,
+                     [&](const tbb::blocked_range2d<int>& r) {
+                         for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+                             for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+                                 A[i*n+j] = static_cast<double>(i+j);
+                                 B[i*n+j] = 0.0;
+                             }
+                         }
+                      }
+                   );
 
   for (auto iter = 0; iter<=iterations; iter++) {
 
@@ -232,32 +163,40 @@ int main(int argc, char * argv[])
     // Apply the stencil operator
     if (star) {
         switch (radius) {
-            case 1: ParallelStar<1>(n, tile_size, A, B); break;
-            case 2: ParallelStar<2>(n, tile_size, A, B); break;
-            case 3: ParallelStar<3>(n, tile_size, A, B); break;
-            case 4: ParallelStar<4>(n, tile_size, A, B); break;
-            case 5: ParallelStar<5>(n, tile_size, A, B); break;
-            case 6: ParallelStar<6>(n, tile_size, A, B); break;
-            case 7: ParallelStar<7>(n, tile_size, A, B); break;
-            case 8: ParallelStar<8>(n, tile_size, A, B); break;
-            case 9: ParallelStar<9>(n, tile_size, A, B); break;
-            default: { std::cerr << "Template not instantiated for radius " << radius << "\n"; break; }
+            case 1: star1(n, tile_size, A, B); break;
+            case 2: star2(n, tile_size, A, B); break;
+            case 3: star3(n, tile_size, A, B); break;
+            case 4: star4(n, tile_size, A, B); break;
+            case 5: star5(n, tile_size, A, B); break;
+            case 6: star6(n, tile_size, A, B); break;
+            case 7: star7(n, tile_size, A, B); break;
+            case 8: star8(n, tile_size, A, B); break;
+            case 9: star9(n, tile_size, A, B); break;
+            default: { std::cerr << "star template not instantiated for radius " << radius << "\n"; break; }
         }
     } else {
         switch (radius) {
-            case 1: ParallelGrid<1>(n, tile_size, A, B); break;
-            case 2: ParallelGrid<2>(n, tile_size, A, B); break;
-            case 3: ParallelGrid<3>(n, tile_size, A, B); break;
-            case 4: ParallelGrid<4>(n, tile_size, A, B); break;
-            case 5: ParallelGrid<5>(n, tile_size, A, B); break;
-            case 6: ParallelGrid<6>(n, tile_size, A, B); break;
-            case 7: ParallelGrid<7>(n, tile_size, A, B); break;
-            case 8: ParallelGrid<8>(n, tile_size, A, B); break;
-            case 9: ParallelGrid<9>(n, tile_size, A, B); break;
-            default: { std::cerr << "Template not instantiated for radius " << radius << "\n"; break; }
+            case 1: grid1(n, tile_size, A, B); break;
+            case 2: grid2(n, tile_size, A, B); break;
+            case 3: grid3(n, tile_size, A, B); break;
+            case 4: grid4(n, tile_size, A, B); break;
+            case 5: grid5(n, tile_size, A, B); break;
+            case 6: grid6(n, tile_size, A, B); break;
+            case 7: grid7(n, tile_size, A, B); break;
+            case 8: grid8(n, tile_size, A, B); break;
+            case 9: grid9(n, tile_size, A, B); break;
+            default: { std::cerr << "grid template not instantiated for radius " << radius << "\n"; break; }
         }
     }
-    ParallelAdd(n, tile_size, A);
+    tbb::parallel_for( range,
+                       [&](const tbb::blocked_range2d<int>& r) {
+                           for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+                               for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+                                   A[i*n+j] += 1.0;
+                               }
+                           }
+                        }
+                     );
   }
   stencil_time = prk::wtime() - stencil_time;
 

--- a/Cxx11/stencil_tbb.hpp
+++ b/Cxx11/stencil_tbb.hpp
@@ -1,31 +1,24 @@
 #define RESTRICT __restrict__
 
-template <>
-struct Star<1> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void star1(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(1, n-1, tile_size, 1, n-1, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-1)*n+(j+0)] * -0.5
                       +in[(i+0)*n+(j+-1)] * -0.5
                       +in[(i+0)*n+(j+1)] * 0.5
                       +in[(i+1)*n+(j+0)] * 0.5;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Star(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Star<2> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void star2(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(2, n-2, tile_size, 2, n-2, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-2)*n+(j+0)] * -0.125
                       +in[(i+-1)*n+(j+0)] * -0.25
                       +in[(i+0)*n+(j+-2)] * -0.125
@@ -34,23 +27,16 @@ struct Star<2> {
                       +in[(i+0)*n+(j+2)] * 0.125
                       +in[(i+1)*n+(j+0)] * 0.25
                       +in[(i+2)*n+(j+0)] * 0.125;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Star(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Star<3> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void star3(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(3, n-3, tile_size, 3, n-3, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-3)*n+(j+0)] * -0.05555555555555555
                       +in[(i+-2)*n+(j+0)] * -0.08333333333333333
                       +in[(i+-1)*n+(j+0)] * -0.16666666666666666
@@ -63,23 +49,16 @@ struct Star<3> {
                       +in[(i+1)*n+(j+0)] * 0.16666666666666666
                       +in[(i+2)*n+(j+0)] * 0.08333333333333333
                       +in[(i+3)*n+(j+0)] * 0.05555555555555555;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Star(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Star<4> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void star4(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(4, n-4, tile_size, 4, n-4, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-4)*n+(j+0)] * -0.03125
                       +in[(i+-3)*n+(j+0)] * -0.041666666666666664
                       +in[(i+-2)*n+(j+0)] * -0.0625
@@ -96,23 +75,16 @@ struct Star<4> {
                       +in[(i+2)*n+(j+0)] * 0.0625
                       +in[(i+3)*n+(j+0)] * 0.041666666666666664
                       +in[(i+4)*n+(j+0)] * 0.03125;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Star(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Star<5> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void star5(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(5, n-5, tile_size, 5, n-5, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-5)*n+(j+0)] * -0.02
                       +in[(i+-4)*n+(j+0)] * -0.025
                       +in[(i+-3)*n+(j+0)] * -0.03333333333333333
@@ -133,23 +105,16 @@ struct Star<5> {
                       +in[(i+3)*n+(j+0)] * 0.03333333333333333
                       +in[(i+4)*n+(j+0)] * 0.025
                       +in[(i+5)*n+(j+0)] * 0.02;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Star(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Star<6> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void star6(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(6, n-6, tile_size, 6, n-6, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-6)*n+(j+0)] * -0.013888888888888888
                       +in[(i+-5)*n+(j+0)] * -0.016666666666666666
                       +in[(i+-4)*n+(j+0)] * -0.020833333333333332
@@ -174,23 +139,16 @@ struct Star<6> {
                       +in[(i+4)*n+(j+0)] * 0.020833333333333332
                       +in[(i+5)*n+(j+0)] * 0.016666666666666666
                       +in[(i+6)*n+(j+0)] * 0.013888888888888888;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Star(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Star<7> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void star7(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(7, n-7, tile_size, 7, n-7, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-7)*n+(j+0)] * -0.01020408163265306
                       +in[(i+-6)*n+(j+0)] * -0.011904761904761904
                       +in[(i+-5)*n+(j+0)] * -0.014285714285714285
@@ -219,23 +177,16 @@ struct Star<7> {
                       +in[(i+5)*n+(j+0)] * 0.014285714285714285
                       +in[(i+6)*n+(j+0)] * 0.011904761904761904
                       +in[(i+7)*n+(j+0)] * 0.01020408163265306;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Star(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Star<8> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void star8(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(8, n-8, tile_size, 8, n-8, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-8)*n+(j+0)] * -0.0078125
                       +in[(i+-7)*n+(j+0)] * -0.008928571428571428
                       +in[(i+-6)*n+(j+0)] * -0.010416666666666666
@@ -268,23 +219,16 @@ struct Star<8> {
                       +in[(i+6)*n+(j+0)] * 0.010416666666666666
                       +in[(i+7)*n+(j+0)] * 0.008928571428571428
                       +in[(i+8)*n+(j+0)] * 0.0078125;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Star(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Star<9> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void star9(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(9, n-9, tile_size, 9, n-9, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-9)*n+(j+0)] * -0.006172839506172839
                       +in[(i+-8)*n+(j+0)] * -0.006944444444444444
                       +in[(i+-7)*n+(j+0)] * -0.007936507936507936
@@ -321,23 +265,16 @@ struct Star<9> {
                       +in[(i+7)*n+(j+0)] * 0.007936507936507936
                       +in[(i+8)*n+(j+0)] * 0.006944444444444444
                       +in[(i+9)*n+(j+0)] * 0.006172839506172839;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Star(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Grid<1> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void grid1(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(1, n-1, tile_size, 1, n-1, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-1)*n+(j+-1)] * -0.25
                       +in[(i+-1)*n+(j+0)] * -0.25
                       +in[(i+0)*n+(j+-1)] * -0.25
@@ -345,23 +282,16 @@ struct Grid<1> {
                       +in[(i+1)*n+(j+0)] * 0.25
                       +in[(i+1)*n+(j+1)] * 0.25
                       ;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Grid(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Grid<2> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void grid2(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(2, n-2, tile_size, 2, n-2, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-2)*n+(j+-2)] * -0.0625
                       +in[(i+-2)*n+(j+-1)] * -0.020833333333333332
                       +in[(i+-2)*n+(j+0)] * -0.020833333333333332
@@ -383,23 +313,16 @@ struct Grid<2> {
                       +in[(i+2)*n+(j+1)] * 0.020833333333333332
                       +in[(i+2)*n+(j+2)] * 0.0625
                       ;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Grid(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Grid<3> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void grid3(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(3, n-3, tile_size, 3, n-3, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-3)*n+(j+-3)] * -0.027777777777777776
                       +in[(i+-3)*n+(j+-2)] * -0.005555555555555556
                       +in[(i+-3)*n+(j+-1)] * -0.005555555555555556
@@ -443,23 +366,16 @@ struct Grid<3> {
                       +in[(i+3)*n+(j+2)] * 0.005555555555555556
                       +in[(i+3)*n+(j+3)] * 0.027777777777777776
                       ;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Grid(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Grid<4> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void grid4(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(4, n-4, tile_size, 4, n-4, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-4)*n+(j+-4)] * -0.015625
                       +in[(i+-4)*n+(j+-3)] * -0.002232142857142857
                       +in[(i+-4)*n+(j+-2)] * -0.002232142857142857
@@ -533,23 +449,16 @@ struct Grid<4> {
                       +in[(i+4)*n+(j+3)] * 0.002232142857142857
                       +in[(i+4)*n+(j+4)] * 0.015625
                       ;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Grid(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Grid<5> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void grid5(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(5, n-5, tile_size, 5, n-5, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-5)*n+(j+-5)] * -0.01
                       +in[(i+-5)*n+(j+-4)] * -0.0011111111111111111
                       +in[(i+-5)*n+(j+-3)] * -0.0011111111111111111
@@ -661,23 +570,16 @@ struct Grid<5> {
                       +in[(i+5)*n+(j+4)] * 0.0011111111111111111
                       +in[(i+5)*n+(j+5)] * 0.01
                       ;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Grid(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Grid<6> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void grid6(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(6, n-6, tile_size, 6, n-6, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-6)*n+(j+-6)] * -0.006944444444444444
                       +in[(i+-6)*n+(j+-5)] * -0.0006313131313131314
                       +in[(i+-6)*n+(j+-4)] * -0.0006313131313131314
@@ -835,23 +737,16 @@ struct Grid<6> {
                       +in[(i+6)*n+(j+5)] * 0.0006313131313131314
                       +in[(i+6)*n+(j+6)] * 0.006944444444444444
                       ;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Grid(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Grid<7> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void grid7(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(7, n-7, tile_size, 7, n-7, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-7)*n+(j+-7)] * -0.00510204081632653
                       +in[(i+-7)*n+(j+-6)] * -0.0003924646781789639
                       +in[(i+-7)*n+(j+-5)] * -0.0003924646781789639
@@ -1063,23 +958,16 @@ struct Grid<7> {
                       +in[(i+7)*n+(j+6)] * 0.0003924646781789639
                       +in[(i+7)*n+(j+7)] * 0.00510204081632653
                       ;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Grid(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Grid<8> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void grid8(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(8, n-8, tile_size, 8, n-8, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-8)*n+(j+-8)] * -0.00390625
                       +in[(i+-8)*n+(j+-7)] * -0.00026041666666666666
                       +in[(i+-8)*n+(j+-6)] * -0.00026041666666666666
@@ -1353,23 +1241,16 @@ struct Grid<8> {
                       +in[(i+8)*n+(j+7)] * 0.00026041666666666666
                       +in[(i+8)*n+(j+8)] * 0.00390625
                       ;
-       }
-     }
-  }
+      }
+    }
+  });
+}
 
-    Grid(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
-
-template <>
-struct Grid<9> {
-  void operator()( const tbb::blocked_range2d<int>& r ) const {
-    for (tbb::blocked_range<int>::const_iterator i=r.rows().begin(); i!=r.rows().end(); ++i ) {
-      for (tbb::blocked_range<int>::const_iterator j=r.cols().begin(); j!=r.cols().end(); ++j ) {
+void grid9(const int n, const int tile_size, std::vector<double> & in, std::vector<double> & out) {
+  tbb::blocked_range2d<int> range(9, n-9, tile_size, 9, n-9, tile_size);
+  tbb::parallel_for( range, [&](const tbb::blocked_range2d<int>& r) {
+    for (auto i=r.rows().begin(); i!=r.rows().end(); ++i ) {
+      for (auto j=r.cols().begin(); j!=r.cols().end(); ++j ) {
         out[i*n+j] += +in[(i+-9)*n+(j+-9)] * -0.0030864197530864196
                       +in[(i+-9)*n+(j+-8)] * -0.00018155410312273057
                       +in[(i+-9)*n+(j+-7)] * -0.00018155410312273057
@@ -1713,15 +1594,8 @@ struct Grid<9> {
                       +in[(i+9)*n+(j+8)] * 0.00018155410312273057
                       +in[(i+9)*n+(j+9)] * 0.0030864197530864196
                       ;
-       }
-     }
-  }
-
-    Grid(int n, std::vector<double> & in, std::vector<double> & out)
-        : n(n), in(in), out(out) { }
-
-    int n;
-    std::vector<double> & in;
-    std::vector<double> & out;
-};
+      }
+    }
+  });
+}
 


### PR DESCRIPTION
transpose implements both 1D and 2D blocking - we compile the latter because it is
faster and consistent with the other blocked implementations.

stencil only implements 2D blocking and is currently the only stencil
implementation with explicit blocking.