### PR TITLE
GCC and Clang fast-math plus Clang SIMD

### DIFF
--- a/Cxx11/prk_util.h
+++ b/Cxx11/prk_util.h
@@ -126,7 +126,9 @@ extern "C" {
 #elif defined(__GNUC__) && defined(__GNUC_MINOR__) && ( ( (__GNUC__ == 4) && (__GNUC_MINOR__ == 9) ) || (__GNUC__ >= 5) )
 # define PRAGMA_SIMD PRAGMA(GCC ivdep)
 #elif defined(__clang__)
-# define PRAGMA_SIMD PRAGMA(clang loop vectorize(enable))
+//# define PRAGMA_SIMD PRAGMA(clang loop vectorize(enable))
+# define PRAGMA_SIMD PRAGMA(clang loop vectorize(assume_safety))
+//# define PRAGMA_SIMD PRAGMA(clang loop vectorize(assume_safety) vectorize_width(4) interleave_count(4))
 #else
 # define PRAGMA_SIMD
 #endif

--- a/common/make.defs.gcc
+++ b/common/make.defs.gcc
@@ -16,7 +16,7 @@ CXX=g++${VERSION} -std=gnu++17
 #
 # -mtune=native is appropriate for most cases.
 # -march=native is appropriate if you want portable binaries.
-DEFAULT_OPT_FLAGS=-g -O3 -mtune=native
+DEFAULT_OPT_FLAGS=-g -O3 -mtune=native -ffast-math
 # If you are compiling for KNL on a Xeon login node, use the following:
 # DEFAULT_OPT_FLAGS=-g -O3 -march=knl
 # See https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html for details.

--- a/common/make.defs.llvm
+++ b/common/make.defs.llvm
@@ -16,10 +16,17 @@ CXX=${LLVM_PATH}clang++ -std=c++1z
 #
 # -mtune=native is appropriate for most cases.
 # -march=native is appropriate if you want portable binaries.
-DEFAULT_OPT_FLAGS=-g -O3 -mtune=native
-# If you are compiling for KNL on a Xeon login node, use the following:
-# DEFAULT_OPT_FLAGS=-g -O3 -march=knl
-# See https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html for details.
+#
+DEFAULT_OPT_FLAGS=-g -O3 -mtune=native -ffast-math
+#
+# If you want to be specific, get the architecture options from:
+#   ${LLVM_PATH}llc --version
+# and then get the CPU/ISA options from (e.g. for x86-64):
+#   ${LLVM_PATH}llc -march=x86-64 -mcpu=help
+#
+# These are useful to understand why the compiler does not vectorize loops:
+#   DEFAULT_OPT_FLAGS+=-Rpass-analysis=loop-vectorize
+#   DEFAULT_OPT_FLAGS+=-Rpass=loop-vectorize
 #
 # OpenMP flags
 #


### PR DESCRIPTION
- add -ffast-math to both GCC and Clang options.
- use a better Clang SIMD pragma (thanks, Hal).
- document useful Clang options in example make.defs.