### PR TITLE
cleanup OpenMP target stencil

### DIFF
--- a/Cxx11/generate-cxx-stencil.py
+++ b/Cxx11/generate-cxx-stencil.py
@@ -152,14 +152,14 @@ def instance(src,model,pattern,r):
 def main():
     for model in ['seq','rangefor','stl','pgnu','pstl','openmp','taskloop','target','tbb','cilk','raja','kokkos']:
       src = open('stencil_'+model+'.hpp','w')
-      src.write('#define RESTRICT __restrict__\n\n')
       if (model=='target'):
-        src.write('OMP( declare target )\n')
+          src.write('#define RESTRICT __restrict__\n\n')
+      #  src.write('OMP( declare target )\n\n')
       for pattern in ['star','grid']:
         for r in range(1,6):
           instance(src,model,pattern,r)
-      if (model=='target'):
-        src.write('OMP( end declare target )\n')
+      #if (model=='target'):
+      #  src.write('OMP( end declare target )\n')
       src.close()
 
 if __name__ == '__main__':

--- a/Cxx11/stencil_cilk.hpp
+++ b/Cxx11/stencil_cilk.hpp
@@ -1,5 +1,3 @@
-#define RESTRICT __restrict__
-
 void star1(const int n, const int t, std::vector<double> & in, std::vector<double> & out) {
     _Cilk_for (auto it=1; it<n-1; it+=t) {
       _Cilk_for (auto jt=1; jt<n-1; jt+=t) {

--- a/Cxx11/stencil_kokkos.hpp
+++ b/Cxx11/stencil_kokkos.hpp
@@ -1,5 +1,3 @@
-#define RESTRICT __restrict__
-
 void star1(const int n, const int t, matrix & in, matrix & out) {
     Kokkos::parallel_for ( Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(1,n-1), KOKKOS_LAMBDA(const int i) {
       PRAGMA_SIMD

--- a/Cxx11/stencil_openmp.hpp
+++ b/Cxx11/stencil_openmp.hpp
@@ -1,5 +1,3 @@
-#define RESTRICT __restrict__
-
 void star1(const int n, const int t, std::vector<double> & in, std::vector<double> & out) {
     OMP_FOR(collapse(2))
     for (auto it=1; it<n-1; it+=t) {

--- a/Cxx11/stencil_pgnu.hpp
+++ b/Cxx11/stencil_pgnu.hpp
@@ -1,5 +1,3 @@
-#define RESTRICT __restrict__
-
 void star1(const int n, const int t, std::vector<double> & in, std::vector<double> & out) {
     auto inside = boost::irange(1,n-1);
     __gnu_parallel::for_each( std::begin(inside), std::end(inside), [&] (int i) {

--- a/Cxx11/stencil_pstl.hpp
+++ b/Cxx11/stencil_pstl.hpp
@@ -1,5 +1,3 @@
-#define RESTRICT __restrict__
-
 void star1(const int n, const int t, std::vector<double> & in, std::vector<double> & out) {
     auto inside = boost::irange(1,n-1);
     std::for_each( std::execution::par, std::begin(inside), std::end(inside), [&] (int i) {

--- a/Cxx11/stencil_raja.hpp
+++ b/Cxx11/stencil_raja.hpp
@@ -1,5 +1,3 @@
-#define RESTRICT __restrict__
-
 void star1(const int n, const int t, std::vector<double> & in, std::vector<double> & out) {
     RAJA::forall<thread_exec>(RAJA::Index_type(1), RAJA::Index_type(n-1), [&](RAJA::Index_type i) {
       RAJA::forall<RAJA::simd_exec>(RAJA::Index_type(1), RAJA::Index_type(n-1), [&](RAJA::Index_type j) {

--- a/Cxx11/stencil_rangefor.hpp
+++ b/Cxx11/stencil_rangefor.hpp
@@ -1,5 +1,3 @@
-#define RESTRICT __restrict__
-
 void star1(const int n, const int t, std::vector<double> & in, std::vector<double> & out) {
     auto inside = boost::irange(1,n-1);
     for (auto i : inside) {

--- a/Cxx11/stencil_seq.hpp
+++ b/Cxx11/stencil_seq.hpp
@@ -1,5 +1,3 @@
-#define RESTRICT __restrict__
-
 void star1(const int n, const int t, std::vector<double> & in, std::vector<double> & out) {
     for (auto it=1; it<n-1; it+=t) {
       for (auto jt=1; jt<n-1; jt+=t) {

--- a/Cxx11/stencil_stl.hpp
+++ b/Cxx11/stencil_stl.hpp
@@ -1,5 +1,3 @@
-#define RESTRICT __restrict__
-
 void star1(const int n, const int t, std::vector<double> & in, std::vector<double> & out) {
     auto inside = boost::irange(1,n-1);
     std::for_each( std::begin(inside), std::end(inside), [&] (int i) {

--- a/Cxx11/stencil_target.hpp
+++ b/Cxx11/stencil_target.hpp
@@ -1,6 +1,5 @@
 #define RESTRICT __restrict__
 
-OMP( declare target )
 void star1(const int n, const int t, const double * RESTRICT in, double * RESTRICT out) {
     OMP_TARGET( teams distribute parallel for simd collapse(2) schedule(static,1) )
     for (auto i=1; i<n-1; ++i) {
@@ -396,4 +395,3 @@ void grid5(const int n, const int t, const double * RESTRICT in, double * RESTRI
      }
 }
 
-OMP( end declare target )

--- a/Cxx11/stencil_taskloop.hpp
+++ b/Cxx11/stencil_taskloop.hpp
@@ -1,5 +1,3 @@
-#define RESTRICT __restrict__
-
 void star1(const int n, const int t, std::vector<double> & in, std::vector<double> & out, const int gs) {
     OMP_TASKLOOP_COLLAPSE(2, firstprivate(n) shared(in,out) grainsize(gs) )
     for (auto it=1; it<n-1; it+=t) {

--- a/Cxx11/stencil_tbb.hpp
+++ b/Cxx11/stencil_tbb.hpp
@@ -1,5 +1,3 @@
-#define RESTRICT __restrict__
-
 void star1(const int n, const int t, std::vector<double> & in, std::vector<double> & out) {
   tbb::blocked_range2d<int> range(1, n-1, t, 1, n-1, t);
   tbb::parallel_for( range, [&](decltype(range)& r ) {


### PR DESCRIPTION
- code generator only needs to define RESTRICT for OpenMP target,
  as the rest use stl::vector
- GPU-style target means the functions are invoked on host, so must
  remove "declare target" for correctness (caught by LLVM 5)