### PR TITLE
Legion update to match a minor default mapper interface update

### DIFF
--- a/LEGION/Stencil/stencil.cc
+++ b/LEGION/Stencil/stencil.cc
@@ -96,7 +96,8 @@ class StencilMapper : public DefaultMapper
                                 const MapMustEpochInput&      input,
                                       MapMustEpochOutput&     output);
     virtual Memory default_policy_select_target_memory(MapperContext ctx,
-                                            Processor target_proc);
+                                            Processor target_proc,
+                                            const RegionRequirement &req);
   private:
     //std::vector<Processor>& procs_list;
     std::vector<Memory>& sysmems_list;
@@ -119,7 +120,8 @@ StencilMapper::StencilMapper(MapperRuntime *rt, Machine machine, Processor local
 }
 
 Memory StencilMapper::default_policy_select_target_memory(MapperContext ctx,
-                                                         Processor target_proc)
+                                                  Processor target_proc,
+                                                  const RegionRequirement &req)
 {
   return proc_sysmems[target_proc];
 }


### PR DESCRIPTION
This change keeps the Legion stencil code up-to-date with the current Legion default mapper interface.