### PR TITLE
Fix cafrun fix (replaces/fixes/hacks PR #285)

### DIFF
--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -628,6 +628,8 @@ case "$PRK_TARGET" in
             if [ "${CC}" = "gcc" ] ; then
                 if [ "${TRAVIS_OS_NAME}" = "osx" ] ; then
                     # Homebrew installs a symlink in /usr/local/bin
+                    ls -l /usr/local/bin/cafrun || true
+                    which cafrun || true
                     export PRK_LAUNCHER="/usr/local/bin/cafrun --oversubscribe"
                     # OpenCoarrays uses Open-MPI on Mac thanks to Homebrew
                     # see https://github.com/open-mpi/ompi/issues/2956

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -628,14 +628,13 @@ case "$PRK_TARGET" in
             if [ "${CC}" = "gcc" ] ; then
                 if [ "${TRAVIS_OS_NAME}" = "osx" ] ; then
                     # Homebrew installs a symlink in /usr/local/bin
-                    export PRK_LAUNCHER=cafrun
+                    export PRK_LAUNCHER="/usr/local/bin/cafrun --oversubscribe"
                     # OpenCoarrays uses Open-MPI on Mac thanks to Homebrew
                     # see https://github.com/open-mpi/ompi/issues/2956
                     export TMPDIR=/tmp
                 elif [ "${TRAVIS_OS_NAME}" = "linux" ] ; then
                     export PRK_LAUNCHER=$TRAVIS_ROOT/opencoarrays/bin/cafrun
                 fi
-                export PRK_LAUNCHER="$PRK_LAUNCHER --oversubscribe"
                 $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/p2p-coarray       10 1024 1024
                 $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/stencil-coarray   10 1000
                 $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/transpose-coarray 10 1024 1

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -630,17 +630,18 @@ case "$PRK_TARGET" in
                     # Homebrew installs a symlink in /usr/local/bin
                     ls -l /usr/local/bin/cafrun || true
                     which cafrun || true
-                    export PRK_LAUNCHER="/usr/local/bin/cafrun --oversubscribe"
+                    export PRK_LAUNCHER="/usr/local/bin/cafrun"
                     # OpenCoarrays uses Open-MPI on Mac thanks to Homebrew
                     # see https://github.com/open-mpi/ompi/issues/2956
+                    export PRK_OVERSUBSCRIBE="--oversubscribe"
                     export TMPDIR=/tmp
                 elif [ "${TRAVIS_OS_NAME}" = "linux" ] ; then
                     export PRK_LAUNCHER=$TRAVIS_ROOT/opencoarrays/bin/cafrun
                 fi
-                $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/p2p-coarray       10 1024 1024
-                $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/stencil-coarray   10 1000
-                $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/transpose-coarray 10 1024 1
-                $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/transpose-coarray 10 1024 32
+                $PRK_LAUNCHER -n $PRK_MPI_PROCS ${PRK_OVERSUBSCRIBE:-} $PRK_TARGET_PATH/p2p-coarray       10 1024 1024
+                $PRK_LAUNCHER -n $PRK_MPI_PROCS ${PRK_OVERSUBSCRIBE:-} $PRK_TARGET_PATH/stencil-coarray   10 1000
+                $PRK_LAUNCHER -n $PRK_MPI_PROCS ${PRK_OVERSUBSCRIBE:-} $PRK_TARGET_PATH/transpose-coarray 10 1024 1
+                $PRK_LAUNCHER -n $PRK_MPI_PROCS ${PRK_OVERSUBSCRIBE:-} $PRK_TARGET_PATH/transpose-coarray 10 1024 32
             elif [ "${CC}" = "icc" ] ; then
                 export FOR_COARRAY_NUM_IMAGES=$PRK_MPI_PROCS
                 $PRK_TARGET_PATH/Synch_p2p/p2p-coarray       10 1024 1024

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -565,7 +565,7 @@ case "$PRK_TARGET" in
                 echo "OFFLOADFLAG=-foffload=\"-O3 -v\"" >> common/make.defs
                 if [ "${TRAVIS_OS_NAME}" = "osx" ] ; then
                     # Homebrew installs a symlink in /usr/local/bin
-                    export PRK_CAFC=caf
+                    export PRK_CAFC=/usr/local/bin/caf
                 elif [ "${TRAVIS_OS_NAME}" = "linux" ] ; then
                     export PRK_CAFC=$TRAVIS_ROOT/opencoarrays/bin/caf
                 fi

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -635,6 +635,7 @@ case "$PRK_TARGET" in
                 elif [ "${TRAVIS_OS_NAME}" = "linux" ] ; then
                     export PRK_LAUNCHER=$TRAVIS_ROOT/opencoarrays/bin/cafrun
                 fi
+                export PRK_LAUNCHER="$PRK_LAUNCHER --oversubscribe"
                 $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/p2p-coarray       10 1024 1024
                 $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/stencil-coarray   10 1000
                 $PRK_LAUNCHER -n $PRK_MPI_PROCS $PRK_TARGET_PATH/transpose-coarray 10 1024 1


### PR DESCRIPTION
`cafrun` is not parsing arguments in any sane way currently. This is a work around (hopefully) to get it working again. TL;DR; `--oversubscribe` should come after `-np <N>`

Hoping this fixes the failing build/test on Travis.