### PR TITLE
Travis CI cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,8 +149,7 @@ matrix:
   - os: linux
     env: PRK_TARGET=allcharm++
   # Sadly, Python is XFAIL because Travis CI's Python 3.4.3 can't find cannot process_time.
-  - compiler: gcc
-    env: PRK_TARGET=allpython
+  - env: PRK_TARGET=allpython
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -148,6 +148,9 @@ matrix:
     env: PRK_TARGET=allmpi
   - os: linux
     env: PRK_TARGET=allcharm++
+  # Sadly, Python is XFAIL because Travis CI's Python 3.4.3 can't find cannot process_time.
+  - compiler: gcc
+    env: PRK_TARGET=allpython
 addons:
   apt:
     sources:

--- a/AMPI/AMR/amr.c
+++ b/AMPI/AMR/amr.c
@@ -294,7 +294,7 @@ void get_BG_data(int load_balance, DTYPE *in_bg, DTYPE *ing_r, int my_ID, long e
                  int Num_procs, long L_width_bg, 
                  long L_istart_bg, long L_iend_bg, long L_jstart_bg, long L_jend_bg,
                  long L_istart_r, long L_iend_r, long L_jstart_r, long L_jend_r,
-                 long G_istart_r, long G_jstart_r, MPI_Comm comm_bg, int comm_r,
+                 long G_istart_r, long G_jstart_r, MPI_Comm comm_bg, MPI_Comm comm_r,
                  long L_istart_r_gross, long L_iend_r_gross, 
                  long L_jstart_r_gross, long L_jend_r_gross, 
                  long L_width_r_true_gross, long L_istart_r_true_gross, long L_iend_r_true_gross,

--- a/MPI1/AMR/amr.c
+++ b/MPI1/AMR/amr.c
@@ -99,7 +99,7 @@ void get_BG_data(int load_balance, DTYPE *in_bg, DTYPE *ing_r, int my_ID, long e
                  int Num_procs, long L_width_bg, 
                  long L_istart_bg, long L_iend_bg, long L_jstart_bg, long L_jend_bg,
                  long L_istart_r, long L_iend_r, long L_jstart_r, long L_jend_r,
-                 long G_istart_r, long G_jstart_r, MPI_Comm comm_bg, int comm_r,
+                 long G_istart_r, long G_jstart_r, MPI_Comm comm_bg, MPI_Comm comm_r,
                  long L_istart_r_gross, long L_iend_r_gross, 
                  long L_jstart_r_gross, long L_jend_r_gross, 
                  long L_width_r_true_gross, long L_istart_r_true_gross, long L_iend_r_true_gross,

--- a/travis/install-deps.sh
+++ b/travis/install-deps.sh
@@ -12,7 +12,14 @@ fi
 TRAVIS_ROOT="$1"
 PRK_TARGET="$2"
 
-MPI_IMPL=mpich
+case ${TRAVIS_OS_NAME} in
+    osx)
+        MPI_IMPL=openmpi
+        ;;
+    linux)
+        MPI_IMPL=mpich
+        ;;
+esac
 
 echo "PWD=$PWD"
 

--- a/travis/install-deps.sh
+++ b/travis/install-deps.sh
@@ -74,7 +74,7 @@ case "$PRK_TARGET" in
         echo "Fortran"
         if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CC}" = "gcc" ] ; then
             brew update || true
-            brew install gcc || brew upgrade gcc || true
+            brew upgrade gcc || brew install gcc || true
         fi
         if [ "${CC}" = "gcc" ] ; then
             sh ./travis/install-opencoarrays.sh $TRAVIS_ROOT

--- a/travis/install-libfabric.sh
+++ b/travis/install-libfabric.sh
@@ -7,8 +7,8 @@ TRAVIS_ROOT="$1"
 
 if [ ! -d "$TRAVIS_ROOT/libfabric" ]; then
     cd $TRAVIS_ROOT
-    #git clone --depth 1 https://github.com/ofiwg/libfabric.git libfabric-source
-    git clone -b 'v1.3.0' --depth 1 https://github.com/ofiwg/libfabric.git libfabric-source
+    git clone --depth 1 https://github.com/ofiwg/libfabric.git libfabric-source
+    #git clone -b 'v1.5.2' --depth 1 https://github.com/ofiwg/libfabric.git libfabric-source
     cd libfabric-source
     ./autogen.sh
     ./configure CC=cc --prefix=$TRAVIS_ROOT/libfabric

--- a/travis/install-mpi.sh
+++ b/travis/install-mpi.sh
@@ -24,10 +24,10 @@ case "$os" in
         brew update
         case "$MPI_IMPL" in
             mpich)
-                brew install mpich || brew upgrade mpich
+                brew upgrade mpich || brew install mpich || true
                 ;;
             openmpi)
-                brew install openmpi || brew upgrade openmpi
+                brew upgrade openmpi || brew install openmpi || true
                 ;;
             *)
                 echo "Unknown MPI implementation: $MPI_IMPL"


### PR DESCRIPTION
- libfabric 1.3.0 has issues on Mac per https://travis-ci.org/ParRes/Kernels/jobs/309794625
- Open-MPI `--oversubscribe` required on Mac now that we use it for MPI-1 not just OpenCoarrays
- Python 3 env in Travis sucks (does not find `process_time`) so we XFAIL.
- Fix AMR bug (MPI communicator was `int` not `MPI_Comm`, which only Open-MPI notices).