### PR TITLE
CUDA: support both float and double

### DIFF
--- a/Cxx11/Makefile
+++ b/Cxx11/Makefile
@@ -102,7 +102,9 @@ kokkos: stencil-kokkos transpose-kokkos nstream-kokkos
 
 raja: p2p-vector-raja stencil-vector-raja transpose-vector-raja nstream-vector-raja
 
-cuda: transpose-cuda transpose-cublas nstream-cuda nstream-cublas
+cuda: transpose-cuda nstream-cuda
+
+cublas: transpose-cublas nstream-cublas
 
 p2p-innerloop-vector: p2p-innerloop-vector-openmp.cc prk_util.h
 	$(CXX) $(CXXFLAGS) $< -o $@

--- a/Cxx11/nstream-cublas.cu
+++ b/Cxx11/nstream-cublas.cu
@@ -116,18 +116,18 @@ int main(int argc, char * argv[])
 
   auto nstream_time = 0.0;
 
-  const size_t bytes = length * sizeof(double);
-  double * h_A;
-  double * h_B;
-  double * h_C;
+  const size_t bytes = length * sizeof(duble);
+  duble * h_A;
+  duble * h_B;
+  duble * h_C;
 #ifndef __CORIANDERCC__
-  prk::CUDA::check( cudaMallocHost((double**)&h_A, bytes) );
-  prk::CUDA::check( cudaMallocHost((double**)&h_B, bytes) );
-  prk::CUDA::check( cudaMallocHost((double**)&h_C, bytes) );
+  prk::CUDA::check( cudaMallocHost((void**)&h_A, bytes) );
+  prk::CUDA::check( cudaMallocHost((void**)&h_B, bytes) );
+  prk::CUDA::check( cudaMallocHost((void**)&h_C, bytes) );
 #else
-  h_A = new double[length];
-  h_B = new double[length];
-  h_C = new double[length];
+  h_A = new duble[length];
+  h_B = new duble[length];
+  h_C = new duble[length];
 #endif
   for (size_t i=0; i<length; ++i) {
     h_A[i] = 0;
@@ -135,12 +135,12 @@ int main(int argc, char * argv[])
     h_C[i] = 2;
   }
 
-  double * d_A;
-  double * d_B;
-  double * d_C;
-  prk::CUDA::check( cudaMalloc((double**)&d_A, bytes) );
-  prk::CUDA::check( cudaMalloc((double**)&d_B, bytes) );
-  prk::CUDA::check( cudaMalloc((double**)&d_C, bytes) );
+  duble * d_A;
+  duble * d_B;
+  duble * d_C;
+  prk::CUDA::check( cudaMalloc((void**)&d_A, bytes) );
+  prk::CUDA::check( cudaMalloc((void**)&d_B, bytes) );
+  prk::CUDA::check( cudaMalloc((void**)&d_C, bytes) );
   prk::CUDA::check( cudaMemcpy(d_A, &(h_A[0]), bytes, cudaMemcpyHostToDevice) );
   prk::CUDA::check( cudaMemcpy(d_B, &(h_B[0]), bytes, cudaMemcpyHostToDevice) );
   prk::CUDA::check( cudaMemcpy(d_C, &(h_C[0]), bytes, cudaMemcpyHostToDevice) );
@@ -156,7 +156,7 @@ int main(int argc, char * argv[])
 
       if (iter==1) nstream_time = prk::wtime();
 
-      double one(1);
+      duble one(1);
       cublasDaxpy(h, length,
                   &one,                       // alpha
                   d_B, 1,                     // x, incx

--- a/Cxx11/nstream-cublas.cu
+++ b/Cxx11/nstream-cublas.cu
@@ -116,18 +116,18 @@ int main(int argc, char * argv[])
 
   auto nstream_time = 0.0;
 
-  const size_t bytes = length * sizeof(duble);
-  duble * h_A;
-  duble * h_B;
-  duble * h_C;
+  const size_t bytes = length * sizeof(double);
+  double * h_A;
+  double * h_B;
+  double * h_C;
 #ifndef __CORIANDERCC__
   prk::CUDA::check( cudaMallocHost((void**)&h_A, bytes) );
   prk::CUDA::check( cudaMallocHost((void**)&h_B, bytes) );
   prk::CUDA::check( cudaMallocHost((void**)&h_C, bytes) );
 #else
-  h_A = new duble[length];
-  h_B = new duble[length];
-  h_C = new duble[length];
+  h_A = new double[length];
+  h_B = new double[length];
+  h_C = new double[length];
 #endif
   for (size_t i=0; i<length; ++i) {
     h_A[i] = 0;
@@ -135,9 +135,9 @@ int main(int argc, char * argv[])
     h_C[i] = 2;
   }
 
-  duble * d_A;
-  duble * d_B;
-  duble * d_C;
+  double * d_A;
+  double * d_B;
+  double * d_C;
   prk::CUDA::check( cudaMalloc((void**)&d_A, bytes) );
   prk::CUDA::check( cudaMalloc((void**)&d_B, bytes) );
   prk::CUDA::check( cudaMalloc((void**)&d_C, bytes) );
@@ -156,7 +156,7 @@ int main(int argc, char * argv[])
 
       if (iter==1) nstream_time = prk::wtime();
 
-      duble one(1);
+      double one(1);
       cublasDaxpy(h, length,
                   &one,                       // alpha
                   d_B, 1,                     // x, incx

--- a/Cxx11/nstream-cuda.cu
+++ b/Cxx11/nstream-cuda.cu
@@ -64,7 +64,7 @@
 #include "prk_util.h"
 #include "prk_cuda.h"
 
-__global__ void nstream(const int n, const double scalar, double * A, const double * B, const double * C)
+__global__ void nstream(const unsigned n, const prk_float scalar, prk_float * A, const prk_float * B, const prk_float * C)
 {
     auto i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i < n) {
@@ -127,31 +127,31 @@ int main(int argc, char * argv[])
 
   auto nstream_time = 0.0;
 
-  const size_t bytes = length * sizeof(double);
-  double * h_A;
-  double * h_B;
-  double * h_C;
+  const size_t bytes = length * sizeof(prk_float);
+  prk_float * h_A;
+  prk_float * h_B;
+  prk_float * h_C;
 #ifndef __CORIANDERCC__
-  prk::CUDA::check( cudaMallocHost((double**)&h_A, bytes) );
-  prk::CUDA::check( cudaMallocHost((double**)&h_B, bytes) );
-  prk::CUDA::check( cudaMallocHost((double**)&h_C, bytes) );
+  prk::CUDA::check( cudaMallocHost((void**)&h_A, bytes) );
+  prk::CUDA::check( cudaMallocHost((void**)&h_B, bytes) );
+  prk::CUDA::check( cudaMallocHost((void**)&h_C, bytes) );
 #else
-  h_A = new double[length];
-  h_B = new double[length];
-  h_C = new double[length];
+  h_A = new prk_float[length];
+  h_B = new prk_float[length];
+  h_C = new prk_float[length];
 #endif
-  for (size_t i=0; i<length; ++i) {
-    h_A[i] = 0;
-    h_B[i] = 2;
-    h_C[i] = 2;
+  for (auto i=0; i<length; ++i) {
+    h_A[i] = static_cast<prk_float>(0);
+    h_B[i] = static_cast<prk_float>(2);
+    h_C[i] = static_cast<prk_float>(2);
   }
 
-  double * d_A;
-  double * d_B;
-  double * d_C;
-  prk::CUDA::check( cudaMalloc((double**)&d_A, bytes) );
-  prk::CUDA::check( cudaMalloc((double**)&d_B, bytes) );
-  prk::CUDA::check( cudaMalloc((double**)&d_C, bytes) );
+  prk_float * d_A;
+  prk_float * d_B;
+  prk_float * d_C;
+  prk::CUDA::check( cudaMalloc((void**)&d_A, bytes) );
+  prk::CUDA::check( cudaMalloc((void**)&d_B, bytes) );
+  prk::CUDA::check( cudaMalloc((void**)&d_C, bytes) );
   prk::CUDA::check( cudaMemcpy(d_A, &(h_A[0]), bytes, cudaMemcpyHostToDevice) );
   prk::CUDA::check( cudaMemcpy(d_B, &(h_B[0]), bytes, cudaMemcpyHostToDevice) );
   prk::CUDA::check( cudaMemcpy(d_C, &(h_C[0]), bytes, cudaMemcpyHostToDevice) );
@@ -163,7 +163,7 @@ int main(int argc, char * argv[])
 
       if (iter==1) nstream_time = prk::wtime();
 
-      nstream<<<dimGrid, dimBlock>>>(length, scalar, d_A, d_B, d_C);
+      nstream<<<dimGrid, dimBlock>>>(static_cast<unsigned>(length), scalar, d_A, d_B, d_C);
 #ifndef __CORIANDERCC__
       // silence "ignoring cudaDeviceSynchronize for now" warning
       prk::CUDA::check( cudaDeviceSynchronize() );
@@ -197,7 +197,7 @@ int main(int argc, char * argv[])
   ar *= length;
 
   double asum(0);
-  for (size_t i=0; i<length; i++) {
+  for (auto i=0; i<length; i++) {
       asum += std::fabs(h_A[i]);
   }
 

--- a/Cxx11/prk_cuda.h
+++ b/Cxx11/prk_cuda.h
@@ -22,6 +22,13 @@
 #error Sorry, no CUBLAS without NVCC.
 #endif
 
+#ifdef __CORIANDERCC__
+// Coriander does not support double
+typedef float prk_float;
+#else
+typedef double prk_float;
+#endif
+
 namespace prk
 {
     namespace CUDA
@@ -58,8 +65,8 @@ namespace prk
 
             public:
                 int maxThreadsPerBlock;
-                std::array<int,3> maxThreadsDim;
-                std::array<int,3> maxGridSize;
+                std::array<unsigned,3> maxThreadsDim;
+                std::array<unsigned,3> maxGridSize;
 
                 info() {
                     prk::CUDA::check( cudaGetDeviceCount(&nDevices) );

--- a/Cxx11/transpose-cublas.cu
+++ b/Cxx11/transpose-cublas.cu
@@ -113,7 +113,7 @@ int main(int argc, char * argv[])
   for (auto j=0; j<order; j++) {
     for (auto i=0; i<order; i++) {
       h_a[j*order+i] = order*j+i;
-      h_b[j*order+i] = 0.0f;
+      h_b[j*order+i] = 0.0;
     }
   }
 
@@ -126,13 +126,13 @@ int main(int argc, char * argv[])
   prk::CUDA::check( cudaMemcpy(d_b, &(h_b[0]), bytes, cudaMemcpyHostToDevice) );
 
 #if 1
-  // We need a vector of ones because CUBLAS daxpy do does
+  // We need a vector of ones because CUBLAS daxpy does not
   // correctly implement incx=0.
   double * h_o;
   prk::CUDA::check( cudaMallocHost((void**)&h_o, bytes) );
   for (auto j=0; j<order; j++) {
     for (auto i=0; i<order; i++) {
-      h_o[j*order+i] = 1;
+      h_o[j*order+i] = 1.0;
     }
   }
   double * d_o;

--- a/Cxx11/transpose-cublas.cu
+++ b/Cxx11/transpose-cublas.cu
@@ -106,8 +106,8 @@ int main(int argc, char * argv[])
   const size_t bytes = nelems * sizeof(double);
   double * h_a;
   double * h_b;
-  prk::CUDA::check( cudaMallocHost((double**)&h_a, bytes) );
-  prk::CUDA::check( cudaMallocHost((double**)&h_b, bytes) );
+  prk::CUDA::check( cudaMallocHost((void**)&h_a, bytes) );
+  prk::CUDA::check( cudaMallocHost((void**)&h_b, bytes) );
 
   // fill A with the sequence 0 to order^2-1 as doubles
   for (auto j=0; j<order; j++) {
@@ -120,8 +120,8 @@ int main(int argc, char * argv[])
   // copy input from host to device
   double * d_a;
   double * d_b;
-  prk::CUDA::check( cudaMalloc((double**)&d_a, bytes) );
-  prk::CUDA::check( cudaMalloc((double**)&d_b, bytes) );
+  prk::CUDA::check( cudaMalloc((void**)&d_a, bytes) );
+  prk::CUDA::check( cudaMalloc((void**)&d_b, bytes) );
   prk::CUDA::check( cudaMemcpy(d_a, &(h_a[0]), bytes, cudaMemcpyHostToDevice) );
   prk::CUDA::check( cudaMemcpy(d_b, &(h_b[0]), bytes, cudaMemcpyHostToDevice) );
 
@@ -129,14 +129,14 @@ int main(int argc, char * argv[])
   // We need a vector of ones because CUBLAS daxpy do does
   // correctly implement incx=0.
   double * h_o;
-  prk::CUDA::check( cudaMallocHost((double**)&h_o, bytes) );
+  prk::CUDA::check( cudaMallocHost((void**)&h_o, bytes) );
   for (auto j=0; j<order; j++) {
     for (auto i=0; i<order; i++) {
       h_o[j*order+i] = 1;
     }
   }
   double * d_o;
-  prk::CUDA::check( cudaMalloc((double**)&d_o, bytes) );
+  prk::CUDA::check( cudaMalloc((void**)&d_o, bytes) );
   prk::CUDA::check( cudaMemcpy(d_o, &(h_o[0]), bytes, cudaMemcpyHostToDevice) );
 #endif
 

--- a/Cxx11/transpose-cuda.cu
+++ b/Cxx11/transpose-cuda.cu
@@ -62,7 +62,7 @@
 const int tile_dim = 32;
 const int block_rows = 8;
 
-__global__ void transpose(int order, double * A, double * B)
+__global__ void transpose(int order, prk_float * A, prk_float * B)
 {
     int x = blockIdx.x * tile_dim + threadIdx.x;
     int y = blockIdx.y * tile_dim + threadIdx.y;
@@ -70,7 +70,7 @@ __global__ void transpose(int order, double * A, double * B)
 
     for (int j = 0; j < tile_dim; j+= block_rows) {
         B[x*width + (y+j)] += A[(y+j)*width + x];
-        A[(y+j)*width + x] += 1.0f;
+        A[(y+j)*width + x] += (prk_float)1;
     }
 }
 
@@ -128,29 +128,29 @@ int main(int argc, char * argv[])
   //////////////////////////////////////////////////////////////////////
 
   const size_t nelems = (size_t)order * (size_t)order;
-  const size_t bytes = nelems * sizeof(double);
-  double * h_a;
-  double * h_b;
+  const size_t bytes = nelems * sizeof(prk_float);
+  prk_float * h_a;
+  prk_float * h_b;
 #ifndef __CORIANDERCC__
-  prk::CUDA::check( cudaMallocHost((double**)&h_a, bytes) );
-  prk::CUDA::check( cudaMallocHost((double**)&h_b, bytes) );
+  prk::CUDA::check( cudaMallocHost((void**)&h_a, bytes) );
+  prk::CUDA::check( cudaMallocHost((void**)&h_b, bytes) );
 #else
-  h_a = new double[nelems];
-  h_b = new double[nelems];
+  h_a = new prk_float[nelems];
+  h_b = new prk_float[nelems];
 #endif
-  // fill A with the sequence 0 to order^2-1 as doubles
+  // fill A with the sequence 0 to order^2-1
   for (auto j=0; j<order; j++) {
     for (auto i=0; i<order; i++) {
-      h_a[j*order+i] = order*j+i;
-      h_b[j*order+i] = 0.0f;
+      h_a[j*order+i] = static_cast<prk_float>(order*j+i);
+      h_b[j*order+i] = static_cast<prk_float>(0);
     }
   }
 
   // copy input from host to device
-  double * d_a;
-  double * d_b;
-  prk::CUDA::check( cudaMalloc((double**)&d_a, bytes) );
-  prk::CUDA::check( cudaMalloc((double**)&d_b, bytes) );
+  prk_float * d_a;
+  prk_float * d_b;
+  prk::CUDA::check( cudaMalloc((void**)&d_a, bytes) );
+  prk::CUDA::check( cudaMalloc((void**)&d_b, bytes) );
   prk::CUDA::check( cudaMemcpy(d_a, &(h_a[0]), bytes, cudaMemcpyHostToDevice) );
   prk::CUDA::check( cudaMemcpy(d_b, &(h_b[0]), bytes, cudaMemcpyHostToDevice) );
 


### PR DESCRIPTION
Tested `float` with Coriander.  Tested `double` on V100 and CUDA 9.0