### PR TITLE
Cxx11 nstream-kokkos

### DIFF
--- a/Cxx11/nstream-kokkos.cc
+++ b/Cxx11/nstream-kokkos.cc
@@ -118,7 +118,7 @@ int main(int argc, char * argv[])
     std::cout << "Number of iterations = " << iterations << std::endl;
     std::cout << "Vector length        = " << length << std::endl;
     std::cout << "Offset               = " << offset << std::endl;
-    std::cout << "Kokkos execution space: " << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
+    std::cout << "Kokkos execution space: " << Kokkos::DefaultExecutionSpace::name() << std::endl;
 
     //////////////////////////////////////////////////////////////////////
     // Allocate space and perform the computation
@@ -138,15 +138,19 @@ int main(int argc, char * argv[])
           B[i] = 2.0;
           C[i] = 2.0;
       });
-
+      Kokkos::fence();
       for (int iter = 0; iter<=iterations; ++iter) {
 
-        if (iter==1) nstream_time = prk::wtime();
+        if (iter==1) {
+          Kokkos::fence();
+          nstream_time = prk::wtime();
+        }
 
         Kokkos::parallel_for(length, KOKKOS_LAMBDA(size_t const i) {
             A[i] += B[i] + scalar * C[i];
         });
       }
+      Kokkos::fence();
       nstream_time = prk::wtime() - nstream_time;
     }
 


### PR DESCRIPTION
This address issue #377 

There are fences missing hence you wont' measure what you think on
asynchronous backends such as CUDA or HPX.  This also fixes using the actual name of the exec space instead of typeid.
Example for CUDA on V100:
Original:
Parallel Research Kernels version 2.16
C++11/Kokkos STREAM triad: A = B + scalar * C
Number of iterations = 1
Vector length        = 100000000
Offset               = 0
Kokkos execution space: N6Kokkos4CudaE
Solution validates
Rate (MB/s): 422188 Avg time (s): 0.00757957

With fences (and name fix):
Parallel Research Kernels version 2.16
C++11/Kokkos STREAM triad: A = B + scalar * C
Number of iterations = 1
Vector length        = 100000000
Offset               = 0
Kokkos execution space: Cuda
Solution validates
Rate (MB/s): 842600 Avg time (s): 0.00379777
