### PR TITLE
Travis linux trisycl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,7 +159,7 @@ addons:
     - ubuntu-toolchain-r-test
     # works on Precise and Trusty
     # see https://docs.travis-ci.com/user/languages/c/ for details
-    - llvm-toolchain-precise-3.8
+    - llvm-toolchain-trusty-5.0
     #  Boost is for Grappa, HPX, C++ rangefor, pstl
     - boost-latest
     packages:
@@ -171,8 +171,7 @@ addons:
     # Required by GUPC
     - libnuma-dev
     # This should provide OpenMP
-    - clang-3.8
-    - clang-3.9
+    - clang-5.0
     # Grappa and HPX use CMake
     - cmake
     # C++ code needs range headers

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -655,13 +655,14 @@ case "$PRK_TARGET" in
 
         # C++ w/ SYCL
         # triSYCL requires Boost.  We are having Boost issues with Travis Linux builds.
-        if [ "${TRAVIS_OS_NAME}" = "osx" ] ; then
+        #if [ "${TRAVIS_OS_NAME}" = "osx" ] ; then
+        if [ "${TRAVIS_OS_NAME}" = "linux" ] ; then
             SYCLDIR=${TRAVIS_ROOT}/triSYCL
             if [ "${CC}" = "clang" ] ; then
                 # SYCL will compile without OpenMP
-                echo "SYCLCXX=${PRK_CXX} -pthread -std=c++1z" >> common/make.defs
+                echo "SYCLCXX=${PRK_CXX} -pthread -O3 -std=c++1z" >> common/make.defs
             else
-                echo "SYCLCXX=${PRK_CXX} -fopenmp -std=c++1z" >> common/make.defs
+                echo "SYCLCXX=${PRK_CXX} -fopenmp -O3 -std=c++1z" >> common/make.defs
             fi
             echo "SYCLFLAG=-DUSE_SYCL -I${SYCLDIR}/include" >> common/make.defs
             ${MAKE} -C $PRK_TARGET_PATH p2p-hyperplane-sycl stencil-sycl transpose-sycl nstream-sycl

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -283,6 +283,11 @@ case "$PRK_TARGET" in
                         echo "Found C++: $PRK_CXX"
                         break
                     fi
+                    if [ -f "`which /usr/local/Cellar/gcc@${version}/bin/g++-${version}`" ]; then
+                        export PRK_CXX="`which /usr/local/Cellar/gcc@${version}/bin/g++-${version}`"
+                        echo "Found C++: $PRK_CXX"
+                        break
+                    fi
                   done
                 fi
                 if [ "x$PRK_CXX" = "x" ] ; then
@@ -292,16 +297,21 @@ case "$PRK_TARGET" in
             clang++)
                 # Homebrew does not always place the best/latest Clang/LLVM in the default path
                 if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "x$PRK_CXX" = "x" ] ; then
-                  for version in "" "@6" "@5" "@4" ; do
+                  for version in "" "@9" "@8" "@7" "@6" "@5" "@4" ; do
                     if [ -f "`which /usr/local/opt/llvm${version}/bin/clang++`" ]; then
                         export PRK_CXX="`which /usr/local/opt/llvm${version}/bin/clang++`"
+                        echo "Found C++: $PRK_CXX"
+                        break
+                    fi
+                    if [ -f "`which /usr/local/Cellar/llvm${version}/bin/clang++`" ]; then
+                        export PRK_CXX="`which /usr/local/Cellar/llvm${version}/bin/clang++`"
                         echo "Found C++: $PRK_CXX"
                         break
                     fi
                   done
                 fi
                 if [ "x$PRK_CXX" = "x" ] ; then
-                  for version in "-6" "-5" "-4.1" "-4" "-4.0" "-3.9" "-3.8" "-3.7" "-3.6" "" ; do
+                  for version in "-9" "-8" "-7" "-6" "-5" "-4.1" "-4" "-4.0" "-3.9" "-3.8" "-3.7" "-3.6" "" ; do
                     if [ -f "`which ${CXX}${version}`" ]; then
                         export PRK_CXX="${CXX}${version}"
                         echo "Found C++: $PRK_CXX"

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -674,8 +674,31 @@ case "$PRK_TARGET" in
             else
                 echo "SYCLCXX=${PRK_CXX} -fopenmp -O3 -std=c++17" >> common/make.defs
             fi
-            find ${TRAVIS_ROOT}/core/include -name workaround.hpp
-            echo "SYCLFLAG=-DUSE_SYCL -I${SYCLDIR}/include -I${TRAVIS_ROOT}/core/include" >> common/make.defs
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/circular_buffer/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/compute/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/config/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/core/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/log/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/array/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/multi_array/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/optional/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/preprocessor/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/type_index/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/utility/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/assert/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/static_assert/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/exception/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/throw_exception/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/concept_check/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/type_traits/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/iterator/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/mpl/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/detail/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/functional/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/move/include"
+            PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/range/include"
+            echo "SYCLFLAG=-DUSE_SYCL -I${SYCLDIR}/include" $PRK_BOOST_INCLUDE >> common/make.defs
+
             ${MAKE} -C $PRK_TARGET_PATH p2p-hyperplane-sycl stencil-sycl transpose-sycl nstream-sycl
             #$PRK_TARGET_PATH/p2p-hyperplane-sycl 10 50 1 # 100 takes too long :-o
             $PRK_TARGET_PATH/stencil-sycl        10 1000

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -670,9 +670,9 @@ case "$PRK_TARGET" in
             SYCLDIR=${TRAVIS_ROOT}/triSYCL
             if [ "${CC}" = "clang" ] ; then
                 # SYCL will compile without OpenMP
-                echo "SYCLCXX=${PRK_CXX} -pthread -O3 -std=c++1z" >> common/make.defs
+                echo "SYCLCXX=${PRK_CXX} -pthread -O3 -std=c++17" >> common/make.defs
             else
-                echo "SYCLCXX=${PRK_CXX} -fopenmp -O3 -std=c++1z" >> common/make.defs
+                echo "SYCLCXX=${PRK_CXX} -fopenmp -O3 -std=c++17" >> common/make.defs
             fi
             echo "SYCLFLAG=-DUSE_SYCL -I${SYCLDIR}/include -I${TRAVIS_ROOT}/core/include" >> common/make.defs
             ${MAKE} -C $PRK_TARGET_PATH p2p-hyperplane-sycl stencil-sycl transpose-sycl nstream-sycl

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -674,7 +674,7 @@ case "$PRK_TARGET" in
             else
                 echo "SYCLCXX=${PRK_CXX} -fopenmp -O3 -std=c++17" >> common/make.defs
             fi
-            find ${TRAVIS_ROOT}/core/include -name null_deleter.hpp
+            find ${TRAVIS_ROOT}/core/include -name workaround.hpp
             echo "SYCLFLAG=-DUSE_SYCL -I${SYCLDIR}/include -I${TRAVIS_ROOT}/core/include" >> common/make.defs
             ${MAKE} -C $PRK_TARGET_PATH p2p-hyperplane-sycl stencil-sycl transpose-sycl nstream-sycl
             #$PRK_TARGET_PATH/p2p-hyperplane-sycl 10 50 1 # 100 takes too long :-o

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -670,10 +670,11 @@ case "$PRK_TARGET" in
             SYCLDIR=${TRAVIS_ROOT}/triSYCL
             if [ "${CC}" = "clang" ] ; then
                 # SYCL will compile without OpenMP
-                echo "SYCLCXX=${PRK_CXX} -pthread -O3 -std=c++17" >> common/make.defs
+                echo "SYCLCXX=${PRK_CXX} -pthread -O3 -std=c++1z" >> common/make.defs
             else
                 echo "SYCLCXX=${PRK_CXX} -fopenmp -O3 -std=c++17" >> common/make.defs
             fi
+            find ${TRAVIS_ROOT}/core/include -name null_deleter.hpp
             echo "SYCLFLAG=-DUSE_SYCL -I${SYCLDIR}/include -I${TRAVIS_ROOT}/core/include" >> common/make.defs
             ${MAKE} -C $PRK_TARGET_PATH p2p-hyperplane-sycl stencil-sycl transpose-sycl nstream-sycl
             #$PRK_TARGET_PATH/p2p-hyperplane-sycl 10 50 1 # 100 takes too long :-o

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -674,7 +674,7 @@ case "$PRK_TARGET" in
             else
                 echo "SYCLCXX=${PRK_CXX} -fopenmp -O3 -std=c++1z" >> common/make.defs
             fi
-            echo "SYCLFLAG=-DUSE_SYCL -I${SYCLDIR}/include" >> common/make.defs
+            echo "SYCLFLAG=-DUSE_SYCL -I${SYCLDIR}/include -I${TRAVIS_ROOT}/core/include" >> common/make.defs
             ${MAKE} -C $PRK_TARGET_PATH p2p-hyperplane-sycl stencil-sycl transpose-sycl nstream-sycl
             #$PRK_TARGET_PATH/p2p-hyperplane-sycl 10 50 1 # 100 takes too long :-o
             $PRK_TARGET_PATH/stencil-sycl        10 1000

--- a/travis/build-run-prk.sh
+++ b/travis/build-run-prk.sh
@@ -670,9 +670,9 @@ case "$PRK_TARGET" in
             SYCLDIR=${TRAVIS_ROOT}/triSYCL
             if [ "${CC}" = "clang" ] ; then
                 # SYCL will compile without OpenMP
-                echo "SYCLCXX=${PRK_CXX} -pthread -O3 -std=c++1z" >> common/make.defs
+                echo "SYCLCXX=${PRK_CXX} -pthread -O3 -std=c++1z -DTRISYCL" >> common/make.defs
             else
-                echo "SYCLCXX=${PRK_CXX} -fopenmp -O3 -std=c++17" >> common/make.defs
+                echo "SYCLCXX=${PRK_CXX} -fopenmp -O3 -std=c++17 -DTRISYCL" >> common/make.defs
             fi
             PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/circular_buffer/include"
             PRK_BOOST_INCLUDE="${PRK_BOOST_INCLUDE} -I${TRAVIS_ROOT}/compute/include"

--- a/travis/install-boost.sh
+++ b/travis/install-boost.sh
@@ -17,5 +17,6 @@ case "$os" in
         # Boost.Compute is a header-only library
         #git clone --depth 1 https://github.com/kylelutz/compute.git ${TRAVIS_ROOT}/compute
         #git clone --depth 1 https://github.com/boostorg/compute.git ${TRAVIS_ROOT}/compute
+        git clone --depth 1 https://github.com/boostorg/core.git ${TRAVIS_ROOT}/core
         ;;
 esac

--- a/travis/install-boost.sh
+++ b/travis/install-boost.sh
@@ -18,5 +18,6 @@ case "$os" in
         #git clone --depth 1 https://github.com/kylelutz/compute.git ${TRAVIS_ROOT}/compute
         #git clone --depth 1 https://github.com/boostorg/compute.git ${TRAVIS_ROOT}/compute
         git clone --depth 1 https://github.com/boostorg/core.git ${TRAVIS_ROOT}/core
+        git clone --depth 1 https://github.com/boostorg/config.git ${TRAVIS_ROOT}/config
         ;;
 esac

--- a/travis/install-boost.sh
+++ b/travis/install-boost.sh
@@ -16,8 +16,11 @@ case "$os" in
         # We do not test Boost.Compute on Linux because of OpenCL issues...
         # Boost.Compute is a header-only library
         #git clone --depth 1 https://github.com/kylelutz/compute.git ${TRAVIS_ROOT}/compute
-        for sp in core config multi_array optional log compute preprocessor circular_buffer type_index utility ; do
+        for sp in  circular_buffer compute config core log array multi_array optional \
+                   preprocessor type_index utility assert static_assert exception throw_exception \
+                   concept_check type_traits iterator mpl detail functional move range ; do
             git clone --depth 1 https://github.com/boostorg/${sp}.git ${TRAVIS_ROOT}/${sp}
         done
         ;;
 esac
+

--- a/travis/install-boost.sh
+++ b/travis/install-boost.sh
@@ -16,8 +16,8 @@ case "$os" in
         # We do not test Boost.Compute on Linux because of OpenCL issues...
         # Boost.Compute is a header-only library
         #git clone --depth 1 https://github.com/kylelutz/compute.git ${TRAVIS_ROOT}/compute
-        #git clone --depth 1 https://github.com/boostorg/compute.git ${TRAVIS_ROOT}/compute
-        git clone --depth 1 https://github.com/boostorg/core.git ${TRAVIS_ROOT}/core
-        git clone --depth 1 https://github.com/boostorg/config.git ${TRAVIS_ROOT}/config
+        for sp in core config multi_array optional log compute preprocessor circular_buffer type_index utility ; do
+            git clone --depth 1 https://github.com/boostorg/${sp}.git ${TRAVIS_ROOT}/${sp}
+        done
         ;;
 esac

--- a/travis/install-deps.sh
+++ b/travis/install-deps.sh
@@ -66,11 +66,7 @@ case "$PRK_TARGET" in
         sh ./travis/install-tbb.sh $TRAVIS_ROOT
         sh ./travis/install-pstl.sh $TRAVIS_ROOT
         sh ./travis/install-ranges.sh $TRAVIS_ROOT
-        # Boost is whitelisted and obtained from package manager
-        if [ "${TRAVIS_OS_NAME}" = "osx" ] ; then
-            sh ./travis/install-boost.sh $TRAVIS_ROOT
-        fi
-        # CMake 3.10 or higher is required.
+        sh ./travis/install-boost.sh $TRAVIS_ROOT
         sh ./travis/install-cmake.sh $TRAVIS_ROOT
         #sh ./travis/install-raja.sh $TRAVIS_ROOT
         sh ./travis/install-kokkos.sh $TRAVIS_ROOT


### PR DESCRIPTION
Replaces https://github.com/ParRes/Kernels/pull/403 because Travis CI is behaving very badly right now.