### PR TITLE
Add initial hipSYCL support

### DIFF
--- a/Cxx11/nstream-explicit-sycl.cc
+++ b/Cxx11/nstream-explicit-sycl.cc
@@ -245,6 +245,7 @@ int main(int argc, char * argv[])
 #endif
 
   try {
+#if SYCL_TRY_CPU_QUEUE
     if (length<100000) {
         cl::sycl::queue host(cl::sycl::host_selector{});
 #ifndef TRISYCL
@@ -258,11 +259,13 @@ int main(int argc, char * argv[])
     } else {
         std::cout << "Skipping host device since it is too slow for large problems" << std::endl;
     }
+#endif
 
     // CPU requires spir64 target
+#if SYCL_TRY_CPU_QUEUE
     if (1) {
         cl::sycl::queue cpu(cl::sycl::cpu_selector{});
-#ifndef TRISYCL
+#if !defined(TRISYCL) && !defined(__HIPSYCL__)
         auto device      = cpu.get_device();
         auto platform    = device.get_platform();
         std::cout << "SYCL Device:   " << device.get_info<cl::sycl::info::device::name>() << std::endl;
@@ -276,11 +279,13 @@ int main(int argc, char * argv[])
           run<double>(cpu, iterations, length);
         }
     }
+#endif
 
     // NVIDIA GPU requires ptx64 target and does not work very well
+#if SYCL_TRY_GPU_QUEUE
     if (1) {
         cl::sycl::queue gpu(cl::sycl::gpu_selector{});
-#ifndef TRISYCL
+#if !defined(TRISYCL) && !defined(__HIPSYCL__)
         auto device      = gpu.get_device();
         auto platform    = device.get_platform();
         std::cout << "SYCL Device:   " << device.get_info<cl::sycl::info::device::name>() << std::endl;
@@ -310,6 +315,7 @@ int main(int argc, char * argv[])
 #endif
         }
     }
+#endif
   }
   catch (cl::sycl::exception e) {
     std::cout << e.what() << std::endl;

--- a/Cxx11/nstream-explicit-sycl.cc
+++ b/Cxx11/nstream-explicit-sycl.cc
@@ -142,7 +142,7 @@ void run(cl::sycl::queue & q, int iterations, size_t length)
     });
     q.wait();
   }
-  catch (cl::sycl::exception e) {
+  catch (cl::sycl::exception & e) {
     std::cout << e.what() << std::endl;
 #ifdef __COMPUTECPP__
     std::cout << e.get_file_name() << std::endl;
@@ -153,7 +153,7 @@ void run(cl::sycl::queue & q, int iterations, size_t length)
 #endif
     return;
   }
-  catch (std::exception e) {
+  catch (std::exception & e) {
     std::cout << e.what() << std::endl;
     return;
   }
@@ -317,7 +317,7 @@ int main(int argc, char * argv[])
     }
 #endif
   }
-  catch (cl::sycl::exception e) {
+  catch (cl::sycl::exception & e) {
     std::cout << e.what() << std::endl;
 #ifdef __COMPUTECPP__
     std::cout << e.get_file_name() << std::endl;
@@ -328,7 +328,7 @@ int main(int argc, char * argv[])
 #endif
     return 1;
   }
-  catch (std::exception e) {
+  catch (std::exception & e) {
     std::cout << e.what() << std::endl;
     return 1;
   }

--- a/Cxx11/nstream-sycl.cc
+++ b/Cxx11/nstream-sycl.cc
@@ -227,6 +227,7 @@ int main(int argc, char * argv[])
 #endif
 
   try {
+#if SYCL_TRY_CPU_QUEUE
     if (length<100000) {
         cl::sycl::queue host(cl::sycl::host_selector{});
 #ifndef TRISYCL
@@ -240,11 +241,13 @@ int main(int argc, char * argv[])
     } else {
         std::cout << "Skipping host device since it is too slow for large problems" << std::endl;
     }
+#endif
 
     // CPU requires spir64 target
+#if SYCL_TRY_CPU_QUEUE
     if (1) {
         cl::sycl::queue cpu(cl::sycl::cpu_selector{});
-#ifndef TRISYCL
+#if !defined(TRISYCL) && !defined(__HIPSYCL__)
         auto device      = cpu.get_device();
         auto platform    = device.get_platform();
         std::cout << "SYCL Device:   " << device.get_info<cl::sycl::info::device::name>() << std::endl;
@@ -258,11 +261,12 @@ int main(int argc, char * argv[])
           run<double>(cpu, iterations, length);
         }
     }
-
+#endif
     // NVIDIA GPU requires ptx64 target and does not work very well
+#if SYCL_TRY_GPU_QUEUE
     if (1) {
         cl::sycl::queue gpu(cl::sycl::gpu_selector{});
-#ifndef TRISYCL
+#if !defined(TRISYCL) && !defined(__HIPSYCL__)
         auto device      = gpu.get_device();
         auto platform    = device.get_platform();
         std::cout << "SYCL Device:   " << device.get_info<cl::sycl::info::device::name>() << std::endl;
@@ -292,6 +296,7 @@ int main(int argc, char * argv[])
 #endif
         }
     }
+#endif
   }
   catch (cl::sycl::exception e) {
     std::cout << e.what() << std::endl;

--- a/Cxx11/nstream-sycl.cc
+++ b/Cxx11/nstream-sycl.cc
@@ -124,7 +124,7 @@ void run(cl::sycl::queue & q, int iterations, size_t length)
     // for other device-oriented programming models.
     nstream_time = prk::wtime() - nstream_time;
   }
-  catch (cl::sycl::exception e) {
+  catch (cl::sycl::exception & e) {
     std::cout << e.what() << std::endl;
 #ifdef __COMPUTECPP__
     std::cout << e.get_file_name() << std::endl;
@@ -135,7 +135,7 @@ void run(cl::sycl::queue & q, int iterations, size_t length)
 #endif
     return;
   }
-  catch (std::exception e) {
+  catch (std::exception & e) {
     std::cout << e.what() << std::endl;
     return;
   }
@@ -298,7 +298,7 @@ int main(int argc, char * argv[])
     }
 #endif
   }
-  catch (cl::sycl::exception e) {
+  catch (cl::sycl::exception & e) {
     std::cout << e.what() << std::endl;
 #ifdef __COMPUTECPP__
     std::cout << e.get_file_name() << std::endl;
@@ -309,7 +309,7 @@ int main(int argc, char * argv[])
 #endif
     return 1;
   }
-  catch (std::exception e) {
+  catch (std::exception & e) {
     std::cout << e.what() << std::endl;
     return 1;
   }

--- a/Cxx11/prk_util.h
+++ b/Cxx11/prk_util.h
@@ -103,7 +103,7 @@
 #define SYCL_TRY_CPU_QUEUE 0
 #endif
 
-#if !defined(__HIPSYCL__) || !defined(HIPSYCL_PLATFORM_CPU)
+#if !defined(__HIPSYCL__) || !defined(HIPSYCL_PLATFORM_GPU)
 #define SYCL_TRY_GPU_QUEUE 1
 #else
 #define SYCL_TRY_GPU_QUEUE 0

--- a/Cxx11/prk_util.h
+++ b/Cxx11/prk_util.h
@@ -82,12 +82,33 @@
 #define PRK_UNUSED
 #endif
 
+
 // for SYCL
-#ifdef TRISYCL
+
+// prebuilt kernels are not required/not fully supported on hipSYCL and triSYCL
+#if defined(TRISYCL) || defined(__HIPSYCL__)
 #define PREBUILD_KERNEL 0
 #else
 #define PREBUILD_KERNEL 1
 #endif
+
+// not all SYCL implementations may support all device types.
+// If an implementation does not find any devices based on a
+// device selector, it will throw an exception.
+// These macros can be used to check if there's any chance
+// of an implementation targeting a CPU and GPU.
+#if !defined(__HIPSYCL__) || defined(HIPSYCL_PLATFORM_CPU)
+#define SYCL_TRY_CPU_QUEUE 1
+#else
+#define SYCL_TRY_CPU_QUEUE 0
+#endif
+
+#if !defined(__HIPSYCL__) || !defined(HIPSYCL_PLATFORM_CPU)
+#define SYCL_TRY_GPU_QUEUE 1
+#else
+#define SYCL_TRY_GPU_QUEUE 0
+#endif
+
 
 namespace prk {
 

--- a/Cxx11/stencil-sycl.cc
+++ b/Cxx11/stencil-sycl.cc
@@ -64,6 +64,7 @@
 #include "prk_util.h"
 #include "stencil_sycl.hpp"
 
+
 #if 0
 #include "prk_opencl.h"
 #define USE_OPENCL 1
@@ -83,7 +84,13 @@ void nothing(cl::sycl::queue & q, const size_t n, cl::sycl::buffer<T> & d_in, cl
     std::cout << "You are trying to use a stencil that does not exist.\n";
     std::cout << "Please generate the new stencil using the code generator\n";
     std::cout << "and add it to the case-switch in the driver." << std::endl;
+    // There seems to be an issue with the clang CUDA/HIP toolchains not having
+    // std::abort() available
+#if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HCC)
+    abort();
+#else
     std::abort();
+#endif
 }
 
 template <typename T>
@@ -322,9 +329,10 @@ int main(int argc, char * argv[])
 
   try {
 
+#if SYCL_TRY_CPU_QUEUE
     if (1) {
         cl::sycl::queue host(cl::sycl::host_selector{});
-#ifndef TRISYCL
+#if !defined(TRISYCL) && !defined(__HIPSYCL__)
         auto device      = host.get_device();
         auto platform    = device.get_platform();
         std::cout << "SYCL Device:   " << device.get_info<cl::sycl::info::device::name>() << std::endl;
@@ -334,11 +342,13 @@ int main(int argc, char * argv[])
         run<float>(host, iterations, n, tile_size, star, radius);
         run<double>(host, iterations, n, tile_size, star, radius);
     }
+#endif
 
     // CPU requires spir64 target
+#if SYCL_TRY_CPU_QUEUE
     if (1) {
         cl::sycl::queue cpu(cl::sycl::cpu_selector{});
-#ifndef TRISYCL
+#if !defined(TRISYCL) && !defined(__HIPSYCL__)
         auto device      = cpu.get_device();
         auto platform    = device.get_platform();
         std::cout << "SYCL Device:   " << device.get_info<cl::sycl::info::device::name>() << std::endl;
@@ -352,11 +362,13 @@ int main(int argc, char * argv[])
           run<double>(cpu, iterations, n, tile_size, star, radius);
         }
     }
+#endif
 
     // NVIDIA GPU requires ptx64 target and does not work very well
+#if SYCL_TRY_GPU_QUEUE
     if (0) {
         cl::sycl::queue gpu(cl::sycl::gpu_selector{});
-#ifndef TRISYCL
+#if !defined(TRISYCL) && !defined(__HIPSYCL__)
         auto device      = gpu.get_device();
         auto platform    = device.get_platform();
         std::cout << "SYCL Device:   " << device.get_info<cl::sycl::info::device::name>() << std::endl;
@@ -386,6 +398,7 @@ int main(int argc, char * argv[])
 #endif
         }
     }
+#endif
   }
   catch (cl::sycl::exception e) {
     std::cout << e.what() << std::endl;

--- a/Cxx11/stencil-sycl.cc
+++ b/Cxx11/stencil-sycl.cc
@@ -195,7 +195,7 @@ void run(cl::sycl::queue & q, int iterations, size_t n, size_t tile_size, bool s
     }
     stencil_time = prk::wtime() - stencil_time;
   }
-  catch (cl::sycl::exception e) {
+  catch (cl::sycl::exception & e) {
     std::cout << e.what() << std::endl;
 #ifdef __COMPUTECPP__
     std::cout << e.get_file_name() << std::endl;
@@ -206,7 +206,7 @@ void run(cl::sycl::queue & q, int iterations, size_t n, size_t tile_size, bool s
 #endif
     return;
   }
-  catch (std::exception e) {
+  catch (std::exception & e) {
     std::cout << e.what() << std::endl;
     return;
   }
@@ -400,7 +400,7 @@ int main(int argc, char * argv[])
     }
 #endif
   }
-  catch (cl::sycl::exception e) {
+  catch (cl::sycl::exception & e) {
     std::cout << e.what() << std::endl;
 #ifdef __COMPUTECPP__
     std::cout << e.get_file_name() << std::endl;
@@ -411,7 +411,7 @@ int main(int argc, char * argv[])
 #endif
     return 1;
   }
-  catch (std::exception e) {
+  catch (std::exception & e) {
     std::cout << e.what() << std::endl;
     return 1;
   }

--- a/Cxx11/transpose-explicit-sycl.cc
+++ b/Cxx11/transpose-explicit-sycl.cc
@@ -157,7 +157,7 @@ void run(cl::sycl::queue & q, int iterations, size_t order)
     });
     q.wait();
   }
-  catch (cl::sycl::exception e) {
+  catch (cl::sycl::exception & e) {
     std::cout << e.what() << std::endl;
 #ifdef __COMPUTECPP__
     std::cout << e.get_file_name() << std::endl;
@@ -168,7 +168,7 @@ void run(cl::sycl::queue & q, int iterations, size_t order)
 #endif
     return;
   }
-  catch (std::exception e) {
+  catch (std::exception & e) {
     std::cout << e.what() << std::endl;
     return;
   }
@@ -328,7 +328,7 @@ int main(int argc, char * argv[])
     }
 #endif
   }
-  catch (cl::sycl::exception e) {
+  catch (cl::sycl::exception & e) {
     std::cout << e.what() << std::endl;
 #ifdef __COMPUTECPP__
     std::cout << e.get_file_name() << std::endl;
@@ -339,7 +339,7 @@ int main(int argc, char * argv[])
 #endif
     return 1;
   }
-  catch (std::exception e) {
+  catch (std::exception & e) {
     std::cout << e.what() << std::endl;
     return 1;
   }

--- a/Cxx11/transpose-explicit-sycl.cc
+++ b/Cxx11/transpose-explicit-sycl.cc
@@ -258,9 +258,10 @@ int main(int argc, char * argv[])
 #endif
 
   try {
+#if SYCL_TRY_CPU_QUEUE
     if (1) {
         cl::sycl::queue host(cl::sycl::host_selector{});
-#ifndef TRISYCL
+#if !defined(TRISYCL) && !defined(__HIPSYCL__)
         auto device      = host.get_device();
         auto platform    = device.get_platform();
         std::cout << "SYCL Device:   " << device.get_info<cl::sycl::info::device::name>() << std::endl;
@@ -269,11 +270,13 @@ int main(int argc, char * argv[])
         run<float>(host, iterations, order);
         run<double>(host, iterations, order);
     }
+#endif
 
     // CPU requires spir64 target
+#if SYCL_TRY_CPU_QUEUE
     if (1) {
         cl::sycl::queue cpu(cl::sycl::cpu_selector{});
-#ifndef TRISYCL
+#if !defined(TRISYCL) && !defined(__HIPSYCL__)
         auto device      = cpu.get_device();
         auto platform    = device.get_platform();
         std::cout << "SYCL Device:   " << device.get_info<cl::sycl::info::device::name>() << std::endl;
@@ -287,11 +290,13 @@ int main(int argc, char * argv[])
           run<double>(cpu, iterations, order);
         }
     }
+#endif
 
     // NVIDIA GPU requires ptx64 target and does not work very well
+#if SYCL_TRY_GPU_QUEUE
     if (0) {
         cl::sycl::queue gpu(cl::sycl::gpu_selector{});
-#ifndef TRISYCL
+#if !defined(TRISYCL) && !defined(__HIPSYCL__)
         auto device      = gpu.get_device();
         auto platform    = device.get_platform();
         std::cout << "SYCL Device:   " << device.get_info<cl::sycl::info::device::name>() << std::endl;
@@ -321,6 +326,7 @@ int main(int argc, char * argv[])
 #endif
         }
     }
+#endif
   }
   catch (cl::sycl::exception e) {
     std::cout << e.what() << std::endl;

--- a/Cxx11/transpose-sycl.cc
+++ b/Cxx11/transpose-sycl.cc
@@ -224,6 +224,7 @@ int main(int argc, char * argv[])
 #endif
 
   try {
+#if SYCL_TRY_CPU_QUEUE
     if (1) {
         cl::sycl::queue host(cl::sycl::host_selector{});
 #ifndef TRISYCL
@@ -235,11 +236,13 @@ int main(int argc, char * argv[])
         run<float>(host, iterations, order);
         run<double>(host, iterations, order);
     }
+#endif
 
     // CPU requires spir64 target
+#if SYCL_TRY_CPU_QUEUE
     if (1) {
         cl::sycl::queue cpu(cl::sycl::cpu_selector{});
-#ifndef TRISYCL
+#if !defined(TRISYCL) && !defined(__HIPSYCL__)
         auto device      = cpu.get_device();
         auto platform    = device.get_platform();
         std::cout << "SYCL Device:   " << device.get_info<cl::sycl::info::device::name>() << std::endl;
@@ -253,11 +256,13 @@ int main(int argc, char * argv[])
           run<double>(cpu, iterations, order);
         }
     }
+#endif
 
     // NVIDIA GPU requires ptx64 target and does not work very well
+#if SYCL_TRY_GPU_QUEUE
     if (0) {
         cl::sycl::queue gpu(cl::sycl::gpu_selector{});
-#ifndef TRISYCL
+#if !defined(TRISYCL) && !defined(__HIPSYCL__)
         auto device      = gpu.get_device();
         auto platform    = device.get_platform();
         std::cout << "SYCL Device:   " << device.get_info<cl::sycl::info::device::name>() << std::endl;
@@ -287,6 +292,7 @@ int main(int argc, char * argv[])
 #endif
         }
     }
+#endif
   }
   catch (cl::sycl::exception e) {
     std::cout << e.what() << std::endl;

--- a/Cxx11/transpose-sycl.cc
+++ b/Cxx11/transpose-sycl.cc
@@ -123,7 +123,7 @@ void run(cl::sycl::queue & q, int iterations, size_t order)
     // for other device-oriented programming models.
     trans_time = prk::wtime() - trans_time;
   }
-  catch (cl::sycl::exception e) {
+  catch (cl::sycl::exception & e) {
     std::cout << e.what() << std::endl;
 #ifdef __COMPUTECPP__
     std::cout << e.get_file_name() << std::endl;
@@ -134,7 +134,7 @@ void run(cl::sycl::queue & q, int iterations, size_t order)
 #endif
     return;
   }
-  catch (std::exception e) {
+  catch (std::exception & e) {
     std::cout << e.what() << std::endl;
     return;
   }
@@ -294,7 +294,7 @@ int main(int argc, char * argv[])
     }
 #endif
   }
-  catch (cl::sycl::exception e) {
+  catch (cl::sycl::exception & e) {
     std::cout << e.what() << std::endl;
 #ifdef __COMPUTECPP__
     std::cout << e.get_file_name() << std::endl;
@@ -305,7 +305,7 @@ int main(int argc, char * argv[])
 #endif
     return 1;
   }
-  catch (std::exception e) {
+  catch (std::exception & e) {
     std::cout << e.what() << std::endl;
     return 1;
   }


### PR DESCRIPTION
This allows the SYCL benchmarks in PRK to be compiled with hipSYCL. Included changes:
* Like triSYCL, hipSYCL does not advertise support for Khronos fp64 or spir extensions, since it does not use OpenCL. So, on hipSYCL, tests should be carried out even if these extensions are not present.
* Like triSYCL, hipSYCL does not need prebuilding kernels
* Depending on the hipSYCL compilation target, CPU and GPU backends may not be available, which may then cause the benchmark to abort since the device selector throws an exception (because no matching device could be found). This is fixed by introducing the `SYCL_TRY_CPU_QUEUE` and `SYCL_TRY_GPU_QUEUE` macros.
The cpu/gpu portions of the benchmarks are only enabled if these macros are set. If not on hipSYCL both are enabled; on hipSYCL they are only enabled if the right backend is targeted (cpu/gpu).
Since the CPU and GPU benchmark runs are already surrounded with `if(1) { ... }` or `if(0) {... }` statements, we could also change this to `if(SYCL_TRY_CPU_QUEUE) {... }` instead of the additional preprocessor if. I did note make this change because the intent behind those if statements was not entirely clear to me.
* A small workaround around a problem with clang's HIP/CUDA toolchain not having `std::abort()` available when compiling for device.

I have tested all SYCL benchmarks both with the hipSYCL CPU and CUDA backend and they work fine, although there seems to be a cleanup issue in hipSYCL on CPU, potentially leading to a crash when the queue goes out of scope. This does not affect the generation and validation of results.