### PR TITLE
clean OpenMP target stencil in C1z

### DIFF
--- a/C1z/generate-c-stencil.py
+++ b/C1z/generate-c-stencil.py
@@ -76,13 +76,13 @@ def instance(src,model,pattern,r):
 def main():
     for model in ['seq','openmp','target','cilk','taskloop']:
       src = open('stencil_'+model+'.h','w')
-      if (model=='target'):
-          src.write('OMP( declare target )\n')
+      #if (model=='target'):
+      #    src.write('OMP( declare target )\n')
       for pattern in ['star','grid']:
         for r in range(1,10):
           instance(src,model,pattern,r)
-      if (model=='target'):
-          src.write('OMP( end declare target )\n')
+      #if (model=='target'):
+      #    src.write('OMP( end declare target )\n')
       src.close()
 
 if __name__ == '__main__':

--- a/C1z/stencil_target.h
+++ b/C1z/stencil_target.h
@@ -1,4 +1,3 @@
-OMP( declare target )
 void star1(const int n, const double * restrict in, double * restrict out) {
     OMP_TARGET( teams distribute parallel for simd collapse(2) schedule(static,1) )
     for (int i=1; i<n-1; i++) {
@@ -1562,4 +1561,3 @@ void grid9(const int n, const double * restrict in, double * restrict out) {
      }
 }
 
-OMP( end declare target )


### PR DESCRIPTION
Same as previous by @jeffhammond in `Cxx11/`:

> - GPU-style target means the functions are invoked on host, so must
>   remove "declare target" for correctness (caught by LLVM 5)

If this pull request is fixing a bug, please link the associated issue.
The rest of this template does not apply.

I encountered the C version of ParRes/Kernels#277 .  I did not create a new issue because the fix was simple and obvious.