### PR TITLE
xlc suppress warning in OpenCL code

### DIFF
--- a/common/make.defs.ibmp9nv
+++ b/common/make.defs.ibmp9nv
@@ -31,7 +31,7 @@ OFFLOADFLAG=-qoffload -qtgtarch=sm_70
 #OPENCLFLAG=-I/opt/pocl/latest/include -L/opt/pocl/latest/lib -lpoclu -I/opt/pocl/latest/share/pocl/include -lOpenCL
 # Linux
 OPENCLDIR=/usr
-OPENCLFLAG=-I${OPENCLDIR} -L${OPENCLDIR}/lib64 -lOpenCL -Wno-deprecated-declarations
+OPENCLFLAG=-I${OPENCLDIR} -L${OPENCLDIR}/lib64 -lOpenCL -Wno-deprecated-declarations -qsuppress=1500-029
 #
 # SYCL flags
 #


### PR DESCRIPTION
1500-029: (W) WARNING: subprogram cl::Platform::getDevices(cl_device_type, std::vector<Device> *) could not be inlined into cl::Context::Context(cl_device_type, cl_context_properties *, void (*)(const char *, const void *, ::size_t, void *), void *, cl_int *).

[ci skip]