### PR TITLE
add Celerity nstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,9 @@ Cxx11/nstream-cublas
 Cxx11/nstream-cuda
 Cxx11/nstream-openmp-target
 Cxx11/nstream-sycl
+Cxx11/nstream-sycl-usm
+Cxx11/nstream-sycl-explicit
+Cxx11/nstream-celerity
 Cxx11/sparse-vector
 Cxx11/stencil-opencl
 Cxx11/stencil-openmp-target

--- a/Cxx11/Makefile
+++ b/Cxx11/Makefile
@@ -46,7 +46,7 @@ PSTLFLAGS = $(PSTLFLAG) $(RANGEFLAGS) -DUSE_PSTL
 RAJAFLAGS = $(RAJAFLAG) -DUSE_RAJA
 THRUSTFLAGS = $(THRUSTFLAG) $(RANGEFLAGS) -DUSE_THRUST
 KOKKOSFLAGS = $(KOKKOSFLAG) $(KOKKOS_BACKEND_FLAG) $(RANGEFLAGS) -DUSE_KOKKOS
-SYCLFLAGS = $(SYCLFLAG) -DUSE_SYCL -DUSE_2D_INDEXING=0
+SYCLFLAGS = $(SYCLFLAG) -DUSE_2D_INDEXING=0
 ORNLACCFLAGS = $(ORNLACCFLAG)
 
 ifdef OCCADIR
@@ -156,13 +156,16 @@ nstream-opencl: nstream-opencl.cc nstream.cl prk_util.h prk_opencl.h
 %-opencl: %-opencl.cc prk_util.h prk_opencl.h
 	$(CXX) $(CXXFLAGS) $< $(OPENCLFLAGS) -o $@
 
-%-sycl: %-sycl.cc prk_util.h
+%-celerity: %-celerity.cc prk_util.h prk_sycl.h
+	$(SYCLCXX) $(CPPFLAGS) $(SYCLFLAGS) $(BOOSTFLAGS) $(CELERITYINC) $(MPIINC) $< $(CELERITYLIB) $(MPILIB) -o $@
+
+%-sycl: %-sycl.cc prk_util.h prk_sycl.h
 	$(SYCLCXX) $(CPPFLAGS) $(SYCLFLAGS) $< -o $@
 
-%-sycl-usm: %-sycl-usm.cc prk_util.h
+%-sycl-usm: %-sycl-usm.cc prk_util.h prk_sycl.h
 	$(SYCLCXX) $(CPPFLAGS) $(SYCLFLAGS) $< -o $@
 
-%-sycl-explicit: %-sycl-explicit.cc prk_util.h
+%-sycl-explicit: %-sycl-explicit.cc prk_util.h prk_sycl.h
 	$(SYCLCXX) $(CPPFLAGS) $(SYCLFLAGS) $< -o $@
 
 %-target: %-target.cc prk_util.h
@@ -259,6 +262,7 @@ clean:
 	-rm -f *-sycl
 	-rm -f *-sycl-explicit
 	-rm -f *-sycl-usm
+	-rm -f *-celerity
 	-rm -f *-tbb
 	-rm -f *-stl
 	-rm -f *-pstl

--- a/Cxx11/nstream-celerity.cc
+++ b/Cxx11/nstream-celerity.cc
@@ -1,0 +1,223 @@
+///
+/// Copyright (c) 2017, Intel Corporation
+///
+/// Redistribution and use in source and binary forms, with or without
+/// modification, are permitted provided that the following conditions
+/// are met:
+///
+/// * Redistributions of source code must retain the above copyright
+///       notice, this list of conditions and the following disclaimer.
+/// * Redistributions in binary form must reproduce the above
+///       copyright notice, this list of conditions and the following
+///       disclaimer in the documentation and/or other materials provided
+///       with the distribution.
+/// * Neither the name of Intel Corporation nor the names of its
+///       contributors may be used to endorse or promote products
+///       derived from this software without specific prior written
+///       permission.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+/// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+/// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+/// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+/// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+/// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+/// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+/// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+/// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+/// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+/// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+
+//////////////////////////////////////////////////////////////////////
+///
+/// NAME:    nstream
+///
+/// PURPOSE: To compute memory bandwidth when adding a vector of a given
+///          number of double precision values to the scalar multiple of
+///          another vector of the same length, and storing the result in
+///          a third vector.
+///
+/// USAGE:   The program takes as input the number
+///          of iterations to loop over the triad vectors, the length of the
+///          vectors, and the offset between vectors
+///
+///          <progname> <# iterations> <vector length> <offset>
+///
+///          The output consists of diagnostics to make sure the
+///          algorithm worked, and of timing statistics.
+///
+/// NOTES:   Bandwidth is determined as the number of words read, plus the
+///          number of words written, times the size of the words, divided
+///          by the execution time. For a vector length of N, the total
+///          number of words read and written is 4*N*sizeof(double).
+///
+///
+/// HISTORY: This code is loosely based on the Stream benchmark by John
+///          McCalpin, but does not follow all the Stream rules. Hence,
+///          reported results should not be associated with Stream in
+///          external publications
+///
+///          Converted to C++11 by Jeff Hammond, November 2017.
+///
+//////////////////////////////////////////////////////////////////////
+
+#include "prk_sycl.h"
+#include "prk_util.h"
+#include <celerity/celerity.h>
+
+int main(int argc, char * argv[])
+{
+  // initializes MPI
+#if 1
+  celerity::runtime::init(&argc, &argv);
+#else
+  celerity::runtime::init(&argc, &argv, sycl_device);
+#endif
+
+  std::cout << "Parallel Research Kernels version " << PRKVERSION << std::endl;
+  std::cout << "C++14/SYCL/Celerity STREAM triad: A = B + scalar * C" << std::endl;
+
+  //////////////////////////////////////////////////////////////////////
+  /// Read and test input parameters
+  //////////////////////////////////////////////////////////////////////
+
+  int iterations, offset;
+  size_t length;
+  try {
+      if (argc < 3) {
+        throw "Usage: <# iterations> <vector length>";
+      }
+
+      iterations  = std::atoi(argv[1]);
+      if (iterations < 1) {
+        throw "ERROR: iterations must be >= 1";
+      }
+
+      length = std::atol(argv[2]);
+      if (length <= 0) {
+        throw "ERROR: vector length must be positive";
+      }
+
+      offset = (argc>3) ? std::atoi(argv[3]) : 0;
+      if (length <= 0) {
+        throw "ERROR: offset must be nonnegative";
+      }
+  }
+  catch (const char * e) {
+    std::cout << e << std::endl;
+    return 1;
+  }
+
+  std::cout << "Number of iterations = " << iterations << std::endl;
+  std::cout << "Vector length        = " << length << std::endl;
+  std::cout << "Offset               = " << offset << std::endl;
+
+  //////////////////////////////////////////////////////////////////////
+  /// Setup SYCL/Celerity environment
+  //////////////////////////////////////////////////////////////////////
+
+  celerity::distr_queue q;
+
+  //////////////////////////////////////////////////////////////////////
+  // Allocate space and perform the computation
+  //////////////////////////////////////////////////////////////////////
+
+  double nstream_time(0);
+
+  const double scalar(3);
+
+  std::vector<double> h_A(length,0);
+  std::vector<double> h_B(length,2);
+  std::vector<double> h_C(length,2);
+
+  try {
+
+    celerity::buffer<double,1> d_A { h_A.data(), sycl::range<1>(h_A.size()) };
+    celerity::buffer<double,1> d_B { h_B.data(), sycl::range<1>(h_B.size()) };
+    celerity::buffer<double,1> d_C { h_C.data(), sycl::range<1>(h_C.size()) };
+
+    for (int iter = 0; iter<=iterations; ++iter) {
+
+      if (iter==1) nstream_time = prk::wtime();
+
+      q.submit([=](celerity::handler& h) {
+
+        auto A = d_A.get_access<sycl::access::mode::read_write>(h,celerity::access::one_to_one<1>());
+        auto B = d_B.get_access<sycl::access::mode::read>(h,celerity::access::one_to_one<1>());
+        auto C = d_C.get_access<sycl::access::mode::read>(h,celerity::access::one_to_one<1>());
+
+        h.parallel_for<class nstream>( sycl::range<1>{length}, [=] (sycl::id<1> it) {
+            const size_t i = it[0];
+            A[i] += B[i] + scalar * C[i];
+        });
+      });
+      //q.wait();
+      q.with_master_access([&](celerity::handler& h) {
+        auto A = d_A.get_access<cl::sycl::access::mode::read>(h, d_A.get_range());
+        h.run([&]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10)); // give the synchronization more time to fail
+            for(int i = 0; i < length; i++) {
+                h_A[i] = A[i];
+            }
+        });
+      });
+    }
+
+    q.slow_full_sync();
+
+    // Stop timer before buffer+accessor destructors fire,
+    // since that will move data, and we do not time that
+    // for other device-oriented programming models.
+    nstream_time = prk::wtime() - nstream_time;
+  }
+  catch (sycl::exception & e) {
+    std::cout << e.what() << std::endl;
+    prk::SYCL::print_exception_details(e);
+    return 1;
+  }
+  catch (std::exception & e) {
+    std::cout << e.what() << std::endl;
+    return 1;
+  }
+  catch (const char * e) {
+    std::cout << e << std::endl;
+    return 1;
+  }
+
+  //////////////////////////////////////////////////////////////////////
+  /// Analyze and output results
+  //////////////////////////////////////////////////////////////////////
+
+  double ar(0);
+  double br(2);
+  double cr(2);
+  for (int i=0; i<=iterations; ++i) {
+      ar += br + scalar * cr;
+  }
+
+  ar *= length;
+
+  double asum(0);
+  for (size_t i=0; i<length; ++i) {
+      asum += std::fabs(h_A[i]);
+  }
+
+  const double epsilon(1.e-8);
+  if (std::fabs(ar-asum)/asum > epsilon) {
+      std::cout << "Failed Validation on output array\n"
+                << std::setprecision(16)
+                << "       Expected checksum: " << ar << "\n"
+                << "       Observed checksum: " << asum << std::endl;
+      std::cout << "ERROR: solution did not validate" << std::endl;
+  } else {
+      std::cout << "Solution validates" << std::endl;
+      double avgtime = nstream_time/iterations;
+      double nbytes = 4.0 * length * sizeof(double);
+      std::cout << 8*sizeof(double) << "B "
+                << "Rate (MB/s): " << 1.e-6*nbytes/avgtime
+                << " Avg time (s): " << avgtime << std::endl;
+  }
+
+  return 0;
+}

--- a/common/make.defs.gcc
+++ b/common/make.defs.gcc
@@ -44,6 +44,9 @@ ORNLACCFLAG=-fopenacc
 #
 # MacOS
 OPENCLFLAG=-framework OpenCL
+# POCL
+# http://portablecl.org/docs/html/using.html#linking-your-program-directly-with-pocl is not correct...
+#OPENCLFLAG=-I/opt/pocl/latest/include -L/opt/pocl/latest/lib -lpoclu -I/opt/pocl/latest/share/pocl/include -lOpenCL
 # Linux
 #OPENCLDIR=/etc/alternatives/opencl-intel-tools
 #OPENCLFLAG=-I${OPENCLDIR} -L${OPENCLDIR}/lib64 -lOpenCL
@@ -52,13 +55,62 @@ METALFLAG=-framework MetalPerformanceShaders
 #
 # SYCL flags
 #
+# Intel SYCL - https://github.com/intel/llvm/blob/sycl/sycl/doc/GetStartedWithSYCLCompiler.md
+#
+#SYCLDIR=/opt/isycl
+#SYCLCXX=${SYCLDIR}/bin/clang++
+#SYCLFLAG=-std=c++17 -O3
+#SYCLFLAG+=-fsycl
+#SYCLFLAG+=-L${SYCLDIR}/lib -lsycl -Wl,-rpath=${SYCLDIR}/lib
+#
+# Intel oneAPI
+#
+#SYCLCXX=dpcpp
+#SYCLFLAG=-fsycl
+#SYCLFLAG+=-std=c++17 -O3
+#SYCLFLAG+=--gcc-toolchain=/opt/rh/devtoolset-7/root/usr
+#SYCLFLAG+=-D_GLIBCXX_USE_CXX11_ABI=1
+#SYCLFLAG+=-stdlib=c++ 
+#
+# CodePlay ComputeCpp
+#
+#SYCLDIR=/opt/sycl/latest
+#SYCLCXX=${SYCLDIR}/bin/compute++
+#SYCLFLAG=-sycl-driver -I$(SYCLDIR)/include -L$(SYCLDIR)/lib -Wl,-rpath=$(SYCLDIR)/lib -lComputeCpp
+#SYCLFLAG+=-std=c++14 -O3
+# This makes a huge difference in e.g. nstream...
+#SYCLFLAG+=-no-serial-memop
+# CentOS7 and Ubuntu14 built for this
+#SYCLFLAG+=-D_GLIBCXX_USE_CXX11_ABI=0
+# PRK header rejects GCC4
+#SYCLFLAG+=--gcc-toolchain=/swtools/gcc/5.4.0
+# If not found automatically
+#SYCLFLAG+=${OPENCLFLAG}
+# NVIDIA target
+#SYCLFLAG+=-sycl-target ptx64
+#
 # triSYCL
+#
 # https://github.com/triSYCL/triSYCL is header-only so just clone in Cxx11 directory...
 #SYCLDIR=./triSYCL
 #SYCLCXX=${CXX} ${OPENMPFLAG} $(DEFAULT_OPT_FLAGS)
 #SYCLFLAG=-std=c++17 -I$(SYCLDIR)/include -DTRISYCL
 #
-METALFLAG=-framework MetalPerformanceShaders
+# hipSYCL
+#
+SYCLDIR=/opt/hipSYCL
+SYCLCXX=${SYCLDIR}/bin/syclcc-clang
+SYCLFLAG=-std=c++17 -O3
+SYCLFLAG+=-DHIPSYCL
+# CPU platform
+SYCLFLAG+=--hipsycl-platform=cpu
+SYCLFLAG+=-Wl,-rpath=/opt/hipSYCL/llvm/lib
+#
+CELERITYDIR=${SYCLDIR}
+CELERITYINC=-I$(CELERITYDIR)/include/celerity -I$(CELERITYDIR)/include/celerity/vendor
+CELERITYLIB=-L$(CELERITYDIR)/lib -lcelerity_runtime
+MPIINC=-I/usr/include/mpich-3.2-x86_64
+MPILIB=-L/usr/lib64/mpich-3.2/lib -lmpi
 #
 # OCCA
 #
@@ -79,6 +131,7 @@ TBBFLAG=-I${TBBDIR}/include -L${TBBDIR}/lib -ltbb
 # Parallel STL, Boost, etc.
 #
 #BOOSTFLAG=-I/usr/local/Cellar/boost/1.71.0/include
+BOOSTFLAG=-I/usr/include/boost169
 RANGEFLAG=-DUSE_BOOST_IRANGE ${BOOSTFLAG}
 #RANGEFLAG=-DUSE_RANGES_TS -I./range-v3/include
 PSTLFLAG=${OPENMPSIMDFLAG} ${TBBFLAG} ${RANGEFLAG}

--- a/common/make.defs.llvm
+++ b/common/make.defs.llvm
@@ -62,11 +62,24 @@ OPENMPFLAG+=-L${LLVM_ROOT}/lib
 # SYCL flags
 #
 # Intel SYCL - https://github.com/intel/llvm/blob/sycl/sycl/doc/GetStartedWithSYCLCompiler.md
+#
 #SYCLDIR=/opt/isycl
 #SYCLCXX=${SYCLDIR}/bin/clang++
-#SYCLFLAG=-fsycl -lsycl -lOpenCL -Wl,-rpath=${SYCLDIR}/lib
+#SYCLFLAG=-std=c++17 -O3
+#SYCLFLAG+=-fsycl
+#SYCLFLAG+=-L${SYCLDIR}/lib -lsycl -Wl,-rpath=${SYCLDIR}/lib
+#
+# Intel oneAPI
+#
+#SYCLCXX=dpcpp
+#SYCLFLAG=-fsycl
 #SYCLFLAG+=-std=c++17 -O3
+#SYCLFLAG+=--gcc-toolchain=/opt/rh/devtoolset-7/root/usr
+#SYCLFLAG+=-D_GLIBCXX_USE_CXX11_ABI=1
+#SYCLFLAG+=-stdlib=c++ 
+#
 # CodePlay ComputeCpp
+#
 #SYCLDIR=/opt/sycl/latest
 #SYCLCXX=${SYCLDIR}/bin/compute++
 #SYCLFLAG=-sycl-driver -I$(SYCLDIR)/include -L$(SYCLDIR)/lib -Wl,-rpath=$(SYCLDIR)/lib -lComputeCpp
@@ -83,10 +96,27 @@ OPENMPFLAG+=-L${LLVM_ROOT}/lib
 #SYCLFLAG+=-sycl-target ptx64
 #
 # triSYCL
+#
 # https://github.com/triSYCL/triSYCL is header-only so just clone in Cxx11 directory...
-SYCLDIR=./triSYCL
-SYCLCXX=${CXX} $(DEFAULT_OPT_FLAGS)
-SYCLFLAG=-std=c++17 -I$(SYCLDIR)/include -DTRISYCL
+#SYCLDIR=./triSYCL
+#SYCLCXX=${CXX} $(DEFAULT_OPT_FLAGS)
+#SYCLFLAG=-std=c++17 -I$(SYCLDIR)/include -DTRISYCL
+#
+# hipSYCL
+#
+SYCLDIR=/opt/hipSYCL
+SYCLCXX=${SYCLDIR}/bin/syclcc-clang
+SYCLFLAG=-std=c++17 -O3
+SYCLFLAG+=-DHIPSYCL
+# CPU platform
+SYCLFLAG+=--hipsycl-platform=cpu
+SYCLFLAG+=-Wl,-rpath=/opt/hipSYCL/llvm/lib
+#
+CELERITYDIR=${SYCLDIR}
+CELERITYINC=-I$(CELERITYDIR)/include/celerity -I$(CELERITYDIR)/include/celerity/vendor
+CELERITYLIB=-L$(CELERITYDIR)/lib -lcelerity_runtime
+MPIINC=-I/usr/include/mpich-3.2-x86_64
+MPILIB=-L/usr/lib64/mpich-3.2/lib -lmpi
 #
 # OCCA
 #
@@ -103,8 +133,9 @@ TBBFLAG=-I${TBBDIR}/include -L${TBBDIR}/lib -ltbb
 # Parallel STL, Boost, etc.
 #
 #BOOSTFLAG=-I/usr/local/Cellar/boost/1.71.0/include
-#RANGEFLAG=-DUSE_BOOST_IRANGE ${BOOSTFLAG}
-RANGEFLAG=-DUSE_RANGES_TS -I./range-v3/include
+BOOSTFLAG=-I/usr/include/boost169
+RANGEFLAG=-DUSE_BOOST_IRANGE ${BOOSTFLAG}
+#RANGEFLAG=-DUSE_RANGES_TS -I./range-v3/include
 PSTLFLAG=${OPENMPSIMDFLAG} ${TBBFLAG} -DUSE_INTEL_PSTL -I./pstl/include ${RANGEFLAG} -Wno-\#pragma-messages
 KOKKOSDIR=/opt/kokkos/clang
 KOKKOSFLAG=-I${KOKKOSDIR}/include -L${KOKKOSDIR}/lib -lkokkos ${OPENMPFLAG} -ldl


### PR DESCRIPTION
## New PRK implementation checklist

### Which kernels are implemented?

- [ ] synch_p2p (p2p)
- [ ] stencil
- [ ] transpose
- [x] nstream
- [ ] dgemm
- [ ] reduce
- [ ] sparse
- [ ] branch
- [ ] random
- [ ] refcount
- [ ] synch_global
- [ ] PIC
- [ ] AMR

### Is Travis CI supported?

- [ ] Yes
- [x] No

Need to add hipSYCL support first, which might be hard.

### Documentation and build examples

See https://github.com/ParRes/Kernels/blob/master/doc/SYCL.md#celerity.  The `make.defs` examples are there for GCC and LLVM, but since hipSYCL is based on Clang, the changes are identical.
