### PR TITLE
remove C99 flag (PGI fix)

### DIFF
--- a/FG_MPI/Transpose/Makefile
+++ b/FG_MPI/Transpose/Makefile
@@ -2,7 +2,7 @@ include ../../common/FG_MPI.defs
 
 ##### User configurable options #####
 
-OPTFLAGS    = $(DEFAULT_OPT_FLAGS) -std=c99
+OPTFLAGS    = $(DEFAULT_OPT_FLAGS)
 #description: change above into something that is a decent optimization on you system
 
 #uncomment any of the following flags (and change values) to change defaults

--- a/MPI1/Transpose/Makefile
+++ b/MPI1/Transpose/Makefile
@@ -2,7 +2,7 @@ include ../../common/MPI.defs
 
 ##### User configurable options #####
 
-OPTFLAGS    = $(DEFAULT_OPT_FLAGS) -std=c99
+OPTFLAGS    = $(DEFAULT_OPT_FLAGS)
 #description: change above into something that is a decent optimization on you system
 
 #uncomment any of the following flags (and change values) to change defaults

--- a/MPIOPENMP/Transpose/Makefile
+++ b/MPIOPENMP/Transpose/Makefile
@@ -2,7 +2,7 @@ include ../../common/MPIOPENMP.defs
 
 ##### User configurable options #####
 
-OPTFLAGS    = $(DEFAULT_OPT_FLAGS) -std=c99
+OPTFLAGS    = $(DEFAULT_OPT_FLAGS)
 #description: change above into something that is a decent optimization on you system
 
 #uncomment any of the following flags (and change values) to change defaults

--- a/MPIRMA/Transpose/Makefile
+++ b/MPIRMA/Transpose/Makefile
@@ -2,7 +2,7 @@ include ../../common/MPI.defs
 
 ##### User configurable options #####
 
-OPTFLAGS    = $(DEFAULT_OPT_FLAGS) -std=c99
+OPTFLAGS    = $(DEFAULT_OPT_FLAGS)
 #description: change above into something that is a decent optimization on you system
 
 #uncomment any of the following flags (and change values) to change defaults

--- a/MPISHM/Transpose/Makefile
+++ b/MPISHM/Transpose/Makefile
@@ -2,7 +2,7 @@ include ../../common/MPI.defs
 
 ##### User configurable options #####
 
-OPTFLAGS    = $(DEFAULT_OPT_FLAGS) -std=c99
+OPTFLAGS    = $(DEFAULT_OPT_FLAGS)
 #description: change above into something that is a decent optimization on you system
 
 #uncomment any of the following flags (and change values) to change defaults


### PR DESCRIPTION
PGI doesn't accept `-std=c99` so remove from build system.  Compilers needing a flag to support C99, which are now limited to the old ones, must set it in `make.defs`.