### PR TITLE
The variable A is freed and used again, free once use is complete

### DIFF
--- a/Cxx11/nstream-sycl-usm.cc
+++ b/Cxx11/nstream-sycl-usm.cc
@@ -124,7 +124,6 @@ void run(sycl::queue & q, int iterations, size_t length)
     // for other device-oriented programming models.
     nstream_time = prk::wtime() - nstream_time;
 
-    sycl::free(A, ctx);
     sycl::free(B, ctx);
     sycl::free(C, ctx);
 
@@ -161,6 +160,8 @@ void run(sycl::queue & q, int iterations, size_t length)
       asum += std::fabs(A[i]);
   }
 
+  sycl::free(A, ctx);
+  
   const double epsilon(1.e-8);
   if (std::fabs(ar-asum)/asum > epsilon) {
       std::cout << "Failed Validation on output array\n"


### PR DESCRIPTION
Fixing a bug where A is freed but then referenced again discovered by Peter Zuzek from Codeplay.