### PR TITLE
Petsc transpose

### DIFF
--- a/C1z/Makefile
+++ b/C1z/Makefile
@@ -57,7 +57,7 @@ openmp: nstream-openmp p2p-simd-openmp p2p-tasks-openmp stencil-openmp transpose
 
 mpi: nstream-mpi
 
-petsc: nstream-petsc
+petsc: nstream-petsc transpose-petsc
 
 memkind: nstream-memkind nstream-memkind-openmp
 

--- a/C1z/nstream-petsc.c
+++ b/C1z/nstream-petsc.c
@@ -99,7 +99,7 @@ int main(int argc, char * argv[])
 
   if (set != PETSC_TRUE || iterations < 1) {
     PetscPrintf(PETSC_COMM_WORLD,"ERROR: iterations must be >= 1\n");
-    PetscPrintf(PETSC_COMM_WORLD,"HELP:  Set wtih -i <iterations>\n");
+    PetscPrintf(PETSC_COMM_WORLD,"HELP:  Set with -i <iterations>\n");
     PetscFinalize();
     return 1;
   }
@@ -108,7 +108,7 @@ int main(int argc, char * argv[])
   ierr = PetscOptionsGetInt(NULL,NULL,"-n",&length,&set); CHKERRQ(ierr);
   if (set != PETSC_TRUE || length <= 0) {
     PetscPrintf(PETSC_COMM_WORLD,"ERROR: Vector length must be greater than 0\n");
-    PetscPrintf(PETSC_COMM_WORLD,"HELP:  Set wtih -n <vector length>\n");
+    PetscPrintf(PETSC_COMM_WORLD,"HELP:  Set with -n <vector length>\n");
     PetscFinalize();
     return 1;
   }

--- a/C1z/prk_petsc.h
+++ b/C1z/prk_petsc.h
@@ -1,6 +1,8 @@
 #ifndef PRK_PETSC_H_
 #define PRK_PETSC_H_
 
+#define PRK_PETSC_USE_MPI 1
+
 #ifdef PRK_PETSC_USE_MPI
 #include <mpi.h>
 #endif

--- a/C1z/prk_petsc.h
+++ b/C1z/prk_petsc.h
@@ -8,5 +8,6 @@
 #include <petsc.h>
 #include <petscsys.h>
 #include <petscvec.h>
+#include <petscmat.h>
 
 #endif // PRK_PETSC_H_

--- a/C1z/transpose-petsc.c
+++ b/C1z/transpose-petsc.c
@@ -165,8 +165,8 @@ int main(int argc, char * argv[])
     }
 
     // create transpose view of A
-    ierr = MatAssemblyBegin(AT, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
     ierr = MatTranspose(A, MAT_REUSE_MATRIX, &AT); CHKERRQ(ierr);
+    ierr = MatAssemblyBegin(AT, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
     ierr = MatAssemblyEnd(AT, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
     // Y+=a*X
     ierr = MatAXPY(B, one, AT, SAME_NONZERO_PATTERN); CHKERRQ(ierr);

--- a/C1z/transpose-petsc.c
+++ b/C1z/transpose-petsc.c
@@ -148,7 +148,7 @@ int main(int argc, char * argv[])
   for (int i=0;i<order; i++) {
     for (int j=0;j<order;j++) {
       PetscReal v = 0;
-      ierr = MatSetValue(A, i, j, v, INSERT_VALUES); CHKERRQ(ierr);
+      ierr = MatSetValue(B, i, j, v, INSERT_VALUES); CHKERRQ(ierr);
     }
   }
   ierr = MatAssemblyEnd(B, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);

--- a/C1z/transpose-petsc.c
+++ b/C1z/transpose-petsc.c
@@ -1,0 +1,225 @@
+///
+/// Copyright (c) 2013, Intel Corporation
+///
+/// Redistribution and use in source and binary forms, with or without
+/// modification, are permitted provided that the following conditions
+/// are met:
+///
+/// * Redistributions of source code must retain the above copyright
+///       notice, this list of conditions and the following disclaimer.
+/// * Redistributions in binary form must reproduce the above
+///       copyright notice, this list of conditions and the following
+///       disclaimer in the documentation and/or other materials provided
+///       with the distribution.
+/// * Neither the name of Intel Corporation nor the names of its
+///       contributors may be used to endorse or promote products
+///       derived from this software without specific prior written
+///       permission.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+/// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+/// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+/// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+/// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+/// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+/// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+/// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+/// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+/// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+/// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+
+//////////////////////////////////////////////////////////////////////
+///
+/// NAME:    transpose
+///
+/// PURPOSE: This program measures the time for the transpose of a
+///          column-major stored matrix into a row-major stored matrix.
+///
+/// USAGE:   Program input is the matrix order and the number of times to
+///          repeat the operation:
+///
+///          transpose <matrix_size> <# iterations> [tile size]
+///
+///          An optional parameter specifies the tile size used to divide the
+///          individual matrix blocks for improved cache and TLB performance.
+///
+///          The output consists of diagnostics to make sure the
+///          transpose worked and timing statistics.
+///
+/// HISTORY: Written by  Rob Van der Wijngaart, February 2009.
+///          Converted to C++11 by Jeff Hammond, February 2016 and May 2017.
+///          C11-ification by Jeff Hammond, June 2017.
+///
+//////////////////////////////////////////////////////////////////////
+
+#include "prk_util.h"
+#include "prk_petsc.h"
+
+static char help[] = "FIXME.\n\n";
+
+int main(int argc, char * argv[])
+{
+  PetscErrorCode ierr;
+  ierr = PetscInitialize(&argc,&argv,(char*)0,help);
+  if (ierr) {
+      PetscPrintf(PETSC_COMM_WORLD,"PetscInitialize failed\n");
+      abort();
+      return -1;
+  }
+
+  PetscPrintf(PETSC_COMM_WORLD,"Parallel Research Kernels version %d\n", PRKVERSION );
+  PetscPrintf(PETSC_COMM_WORLD,"C11/PETSc Transpose: B += A^T\n");
+
+  if (argc == 1) {
+    PetscPrintf(PETSC_COMM_WORLD,"Example arguments:\n");
+    PetscPrintf(PETSC_COMM_WORLD,"  ./transpose-petsc -i <iterations> -n <matrix rank> [-t <tiling>]\\\n");
+    PetscPrintf(PETSC_COMM_WORLD,"                   [-mat_type {dense,seqdense,mpidense}] \\\n");
+    PetscPrintf(PETSC_COMM_WORLD,"                   [-log_view]\n");
+  }
+
+  //////////////////////////////////////////////////////////////////////
+  /// Read and test input parameters
+  //////////////////////////////////////////////////////////////////////
+
+  PetscBool set = PETSC_FALSE;
+
+  PetscInt iterations = -1;
+  ierr = PetscOptionsGetInt(NULL,NULL,"-i",&iterations,&set); CHKERRQ(ierr);
+
+  if (set != PETSC_TRUE || iterations < 1) {
+    PetscPrintf(PETSC_COMM_WORLD,"ERROR: iterations must be >= 1\n");
+    PetscPrintf(PETSC_COMM_WORLD,"HELP:  Set with -i <iterations>\n");
+    PetscFinalize();
+    return 1;
+  }
+
+  PetscInt order = -1;
+  ierr = PetscOptionsGetInt(NULL,NULL,"-n",&order,&set); CHKERRQ(ierr);
+  if (set != PETSC_TRUE || order <= 0) {
+    PetscPrintf(PETSC_COMM_WORLD,"ERROR: Matrix order must be greater than 0\n");
+    PetscPrintf(PETSC_COMM_WORLD,"HELP:  Set with -n <matrix order>\n");
+    PetscFinalize();
+    return 1;
+  }
+
+  int me = 0, np = 1;
+#ifdef PRK_PETSC_USE_MPI
+  MPI_Comm_rank(MPI_COMM_WORLD, &me);
+  MPI_Comm_size(MPI_COMM_WORLD, &np);
+#endif
+  PetscPrintf(PETSC_COMM_WORLD,"Number of processes  = %d\n", np);
+  PetscPrintf(PETSC_COMM_WORLD,"Number of iterations = %d\n", iterations);
+  PetscPrintf(PETSC_COMM_WORLD,"Matrix order         = %d\n", order);
+
+  //////////////////////////////////////////////////////////////////////
+  /// Allocate space for the input and transpose matrix
+  //////////////////////////////////////////////////////////////////////
+
+  double trans_time = 0.0;
+
+  PetscReal zero  = 0;
+  PetscReal one   = 1;
+  PetscReal two   = 2;
+  PetscReal three = 3;
+
+  Mat A;
+  Mat B;
+
+  ierr = MatCreateDense(PETSC_COMM_WORLD, PETSC_DECIDE, PETSC_DECIDE, order, order, NULL, &A); CHKERRQ(ierr);
+  //ierr = MatSetFromOptions(A); CHKERRQ(ierr);
+  //ierr = MatSetSizes(A,PETSC_DECIDE,PETSC_DECIDE,order,order); CHKERRQ(ierr);
+
+  ierr = MatDuplicate(A,MAT_DO_NOT_COPY_VALUES,&B); CHKERRQ(ierr);
+
+  // A[i,j] = (i*order+j);
+  ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
+  for (int i=0;i<order; i++) {
+    for (int j=0;j<order;j++) {
+      PetscReal v = (i*order+j);
+      ierr = MatSetValue(A, i, j, v, INSERT_VALUES); CHKERRQ(ierr);
+    }
+  }
+  ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
+
+  // B[i,j] = 0;
+  ierr = MatAssemblyBegin(B, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
+  for (int i=0;i<order; i++) {
+    for (int j=0;j<order;j++) {
+      PetscReal v = 0;
+      ierr = MatSetValue(A, i, j, v, INSERT_VALUES); CHKERRQ(ierr);
+    }
+  }
+  ierr = MatAssemblyEnd(B, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
+
+  ierr = MatDuplicate(A,MAT_DO_NOT_COPY_VALUES,&B); CHKERRQ(ierr);
+
+  PetscLogEvent prk_event;
+  PetscLogEventRegister("PRK transpose",0,&prk_event);
+
+  for (int iter = 0; iter<=iterations; iter++) {
+
+    if (iter==1) {
+        ierr = PetscBarrier(NULL); CHKERRQ(ierr);
+        trans_time = prk_wtime();
+        ierr = PetscLogEventBegin(prk_event,0,0,0,0); CHKERRQ(ierr);
+    }
+
+    Mat AT;
+    // create transpose view of A
+    ierr = MatDuplicate(A,MAT_DO_NOT_COPY_VALUES,&AT); CHKERRQ(ierr);
+    ierr = MatAssemblyBegin(AT, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
+    ierr = MatCreateTranspose(A, &AT); CHKERRQ(ierr);
+    ierr = MatAssemblyEnd(AT, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
+    // Y+=a*X
+    ierr = MatAXPY(B, one, AT, SAME_NONZERO_PATTERN); CHKERRQ(ierr);
+    // B += A^T
+    // A += 1
+
+  }
+
+  ierr = PetscBarrier(NULL); CHKERRQ(ierr);
+  trans_time = prk_wtime() - trans_time;
+  ierr = PetscLogEventEnd(prk_event,0,0,0,0); CHKERRQ(ierr);
+
+  //////////////////////////////////////////////////////////////////////
+  // Analyze and output results
+  //////////////////////////////////////////////////////////////////////
+
+  PetscReal addit = (iterations+1)*(iterations)/2;
+  PetscReal abserr = 0;
+#if 0
+  for (int j=0; j<order; j++) {
+    for (int i=0; i<order; i++) {
+      const size_t ij = i*order+j;
+      const size_t ji = j*order+i;
+      const double reference = (double)(ij)*(1.+iterations)+addit;
+      abserr += fabs(B[ji] - reference);
+    }
+  }
+#endif
+
+#ifdef VERBOSE
+  PetscPrintf(PETSC_COMM_WORLD,"Sum of absolute differences: %lf\n", abserr);
+#endif
+
+  PetscReal epsilon = 1.0e-8;
+  if (abserr < epsilon) {
+    PetscPrintf(PETSC_COMM_WORLD,"Solution validates\n");
+    const double avgtime = trans_time/iterations;
+    const size_t bytes = order*order*sizeof(double);
+    PetscPrintf(PETSC_COMM_WORLD,"Rate (MB/s): %lf Avg time (s): %lf\n", 2.0e-6 * bytes/avgtime, avgtime );
+  } else {
+    PetscPrintf(PETSC_COMM_WORLD,"ERROR: Aggregate squared error %lf exceeds threshold %lf\n", abserr, epsilon );
+    return 1;
+  }
+
+  ierr = MatDestroy(&A); CHKERRQ(ierr);
+  ierr = MatDestroy(&B); CHKERRQ(ierr);
+
+  PetscFinalize();
+
+  return 0;
+}
+
+

--- a/common/make.defs.cray
+++ b/common/make.defs.cray
@@ -26,15 +26,64 @@ ORNLACCFLAG=-h acc
 #
 # NERSC: "module load boost"
 BOOSTFLAG=-I$${BOOST_DIR}/include
+RANGEFLAG=-DUSE_BOOST_IRANGE ${BOOSTFLAG}
+#RANGEFLAG=-DUSE_RANGES_TS -I./range-v3/include
+PSTLFLAG=${OPENMPSIMDFLAG} ${TBBFLAG} ${RANGEFLAG} -I./pstl/stdlib -I./pstl/include
+KOKKOSDIR=/opt/kokkos/intel
+KOKKOSFLAG=-I${KOKKOSDIR}/include -L${KOKKOSDIR}/lib -lkokkos ${OPENMPFLAG} -ldl
+RAJADIR=/opt/raja/intel
+RAJAFLAG=-I${RAJADIR}/include -L${RAJADIR}/lib -lRAJA ${OPENMPFLAG} ${TBBFLAG}
+THRUSTDIR=/opt/nvidia/thrust
+THRUSTFLAG=-I${THRUSTDIR} ${RANGEFLAG}
 #
 # CBLAS for C++ DGEMM
 #
 CBLASFLAG= # LibSci likely included by default
 #
-# MPI
+# CUDA flags
 #
-# cc wraps gcc, icc or craycc, depending on your PrgEng module.
-MPICC=cc
+# Mac w/ CUDA emulation via https://github.com/hughperkins/coriander
+#NVCC=/opt/llvm/cocl/bin/cocl
+# Linux w/ NVIDIA CUDA
+NVCC=nvcc
+CUDAFLAGS=-g -O3 -std=c++11
+CUDAFLAGS+=-arch=sm_50
+# https://github.com/tensorflow/tensorflow/issues/1066#issuecomment-200574233
+CUDAFLAGS+=-D_MWAITXINTRIN_H_INCLUDED
+#
+# MPI-3
+#
+# We assume you have Intel MPI and have setup your environment with e.g.
+# . /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh
+# in your .bashrc.
+#
+# mpiicc wraps icc.  mpicc and mpigcc wrap gcc.
+MPIDIR=/opt/intel/inteloneapi/mpi/2021.1-beta06
+MPICC=${MPIDIR}/bin/mpiicc
+MPICXX=${MPIDIR}/bin/mpiicpc
+MPIINC=-I${MPIDIR}/include
+MPILIB=-L${MPIDIR}/lib -lmpi
+#MPILIB=-L/usr/local/opt/libevent/lib -L${MPIDIR}/lib -lmpi
+#MPIINC=-I/usr/include/mpich-3.2-x86_64
+#MPILIB=-L/usr/lib64/mpich-3.2/lib -lmpi
+#
+# Global Arrays
+#
+GADIR=../deps/ga
+GAFLAG=-I${GADIR}/include
+GAFLAG+=-L${GADIR}/lib -lga
+GAFLAG+=-L${GADIR}/../armci-mpi/lib -larmci # ARMCI-MPI
+#GAFLAG+=-L${GADIR}/lib -larmci -lcomex     # ARMCI/ComEx
+GAFLAG+=${MPIINC} ${MPILIB}
+GAFLAG+=-lmpifort -lmpi
+GAFLAG+=-i8 # GA is compiled with -i8 on 64-bit systems
+#
+# PETSc
+#
+PETSCDIR=../deps/petsc
+PETSCFLAG=-I${PETSCDIR}/include
+PETSCFLAG+=-L${PETSCDIR}/lib -lpetsc
+PETSCFLAG+=-Wl,-rpath=${PETSCDIR}/lib
 #
 # Fortran 2008 coarrays
 #
@@ -50,3 +99,8 @@ UPCFLAG=-h upc
 #
 # You may need to load a module such as cray-shmem
 SHMEMCC=cc
+#
+# MEMKIND (used in C1z)
+#
+MEMKINDDIR=/home/parallels/PRK/deps
+MEMKINDFLAGS=-I${MEMKINDDIR}/include -L${MEMKINDDIR}/lib -lmemkind -Wl,-rpath=${MEMKINDDIR}/lib

--- a/common/make.defs.gcc
+++ b/common/make.defs.gcc
@@ -70,7 +70,7 @@ METALFLAG=-framework MetalPerformanceShaders
 #SYCLFLAG+=-std=c++17 -O3
 #SYCLFLAG+=--gcc-toolchain=/opt/rh/devtoolset-7/root/usr
 #SYCLFLAG+=-D_GLIBCXX_USE_CXX11_ABI=1
-#SYCLFLAG+=-stdlib=c++ 
+#SYCLFLAG+=-stdlib=c++
 #
 # CodePlay ComputeCpp
 #
@@ -154,7 +154,8 @@ CBLASFLAG=-DACCELERATE -framework Accelerate -flax-vector-conversions
 #NVCC=/opt/llvm/cocl/bin/cocl
 # Linux w/ NVIDIA CUDA
 NVCC=nvcc
-CUDAFLAGS=-g -O3 -std=c++11 -arch=sm_50
+CUDAFLAGS=-g -O3 -std=c++11
+CUDAFLAGS+=-arch=sm_50
 # https://github.com/tensorflow/tensorflow/issues/1066#issuecomment-200574233
 CUDAFLAGS+=-D_MWAITXINTRIN_H_INCLUDED
 #
@@ -163,10 +164,39 @@ CUDAFLAGS+=-D_MWAITXINTRIN_H_INCLUDED
 ISPC=ispc
 ISPCFLAG=-O3 --target=host --opt=fast-math
 #
-# MPI
+# MPI-3
 #
-# We assume you have installed an implementation of MPI-3 that is in your path.
-MPICC=mpicc -std=c99
+# We assume you have Intel MPI and have setup your environment with e.g.
+# . /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh
+# in your .bashrc.
+#
+# mpiicc wraps icc.  mpicc and mpigcc wrap gcc.
+MPIDIR=/opt/intel/inteloneapi/mpi/2021.1-beta06
+MPICC=${MPIDIR}/bin/mpiicc
+MPICXX=${MPIDIR}/bin/mpiicpc
+MPIINC=-I${MPIDIR}/include
+MPILIB=-L${MPIDIR}/lib -lmpi
+#MPILIB=-L/usr/local/opt/libevent/lib -L${MPIDIR}/lib -lmpi
+#MPIINC=-I/usr/include/mpich-3.2-x86_64
+#MPILIB=-L/usr/lib64/mpich-3.2/lib -lmpi
+#
+# Global Arrays
+#
+GADIR=../deps/ga
+GAFLAG=-I${GADIR}/include
+GAFLAG+=-L${GADIR}/lib -lga
+GAFLAG+=-L${GADIR}/../armci-mpi/lib -larmci # ARMCI-MPI
+#GAFLAG+=-L${GADIR}/lib -larmci -lcomex     # ARMCI/ComEx
+GAFLAG+=${MPIINC} ${MPILIB}
+GAFLAG+=-lmpifort -lmpi
+GAFLAG+=-i8 # GA is compiled with -i8 on 64-bit systems
+#
+# PETSc
+#
+PETSCDIR=../deps/petsc
+PETSCFLAG=-I${PETSCDIR}/include
+PETSCFLAG+=-L${PETSCDIR}/lib -lpetsc
+PETSCFLAG+=-Wl,-rpath=${PETSCDIR}/lib
 #
 # Fortran 2008 coarrays
 #
@@ -175,6 +205,8 @@ MPICC=mpicc -std=c99
 COARRAYFLAG=-fcoarray=single -lcaf_single
 # multi-node
 # COARRAYFLAG=-fcoarray=lib -lcaf_mpi
-
+#
+# MEMKIND (used in C1z)
+#
 MEMKINDDIR=/home/parallels/PRK/deps
 MEMKINDFLAGS=-I${MEMKINDDIR}/include -L${MEMKINDDIR}/lib -lmemkind -Wl,-rpath=${MEMKINDDIR}/lib

--- a/common/make.defs.intel
+++ b/common/make.defs.intel
@@ -45,16 +45,62 @@ OPENCLFLAG=-I${OPENCLDIR} -L${OPENCLDIR}/lib64 -lOpenCL
 #
 # SYCL flags
 #
+# Intel SYCL - https://github.com/intel/llvm/blob/sycl/sycl/doc/GetStartedWithSYCLCompiler.md
+#
+#SYCLDIR=/opt/isycl
+#SYCLCXX=${SYCLDIR}/bin/clang++
+#SYCLFLAG=-std=c++17 -O3
+#SYCLFLAG+=-fsycl
+#SYCLFLAG+=-L${SYCLDIR}/lib -lsycl -Wl,-rpath=${SYCLDIR}/lib
+#
+# Intel oneAPI
+#
+#SYCLCXX=dpcpp
+#SYCLFLAG=-fsycl
+#SYCLFLAG+=-std=c++17 -O3
+#SYCLFLAG+=--gcc-toolchain=/opt/rh/devtoolset-7/root/usr
+#SYCLFLAG+=-D_GLIBCXX_USE_CXX11_ABI=1
+#SYCLFLAG+=-stdlib=c++
+#
+# CodePlay ComputeCpp
+#
+#SYCLDIR=/opt/sycl/latest
+#SYCLDIR=/opt/codeplay/latest
+#SYCLCXX=${SYCLDIR}/bin/compute++
+#SYCLFLAG=-sycl-driver -I$(SYCLDIR)/include -L$(SYCLDIR)/lib -Wl,-rpath=$(SYCLDIR)/lib -lComputeCpp
+#SYCLFLAG+=-std=c++14 -O3
+# This makes a huge difference in e.g. nstream...
+#SYCLFLAG+=-no-serial-memop
+# CentOS7 and Ubuntu14 built for this
+#SYCLFLAG+=-D_GLIBCXX_USE_CXX11_ABI=0
+# PRK header rejects GCC4
+#SYCLFLAG+=--gcc-toolchain=/swtools/gcc/5.4.0
+# If not found automatically
+#SYCLFLAG+=${OPENCLFLAG}
+# NVIDIA target
+#SYCLFLAG+=-sycl-target ptx64
+#SYCLFLAG+=-DPRK_NO_OPENCL_GPU
+#
 # triSYCL
+#
 # https://github.com/triSYCL/triSYCL is header-only so just clone in Cxx11 directory...
 SYCLDIR=./triSYCL
 SYCLCXX=${CXX} ${OPENMPFLAG}
 SYCLFLAG=-std=gnu++14 -I$(SYCLDIR)/include
-# ProGTX
-# https://github.com/ProGTX/sycl-gtx
-#SYCLDIR=${HOME}/Work/OpenCL/sycl-gtx
-#SYCLCXX=${CXX} ${OPENMPFLAG}
-#SYCLFLAG=-I${SYCLDIR}/sycl-gtx/include -L${SYCLDIR}/build/sycl-gtx -lsycl-gtx ${OPENCLFLAG}
+#
+# hipSYCL
+#
+#SYCLDIR=/opt/hipSYCL
+#SYCLCXX=${SYCLDIR}/bin/syclcc-clang
+#SYCLFLAG=-std=c++17 -O3
+#SYCLFLAG+=-DHIPSYCL
+# CPU platform
+#SYCLFLAG+=--hipsycl-platform=cpu
+#SYCLFLAG+=-Wl,-rpath=/opt/hipSYCL/llvm/lib
+#
+#CELERITYDIR=${SYCLDIR}
+#CELERITYINC=-I$(CELERITYDIR)/include/celerity -I$(CELERITYDIR)/include/celerity/vendor
+#CELERITYLIB=-L$(CELERITYDIR)/lib -lcelerity_runtime
 #
 # OCCA
 #
@@ -86,6 +132,7 @@ THRUSTFLAG=-I${THRUSTDIR} ${RANGEFLAG}
 #
 #CBLASFLAG=-DACCELERATE -framework Accelerate -flax-vector-conversions
 CBLASFLAG=-DMKL -mkl
+ONEMKLFLAG=-I$(MKLROOT)/include -DMKL_ILP64 ${MKLROOT}/lib/intel64/libmkl_sycl.a  -L${MKLROOT}/lib/intel64 -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lOpenCL -ldl
 #
 # CUDA flags
 #
@@ -103,14 +150,39 @@ CUDAFLAGS+=-D_MWAITXINTRIN_H_INCLUDED
 ISPC=ispc
 ISPCFLAG=-O3 --target=host --opt=fast-math
 #
-# MPI
+# MPI-3
 #
 # We assume you have Intel MPI and have setup your environment with e.g.
 # . /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh
 # in your .bashrc.
 #
 # mpiicc wraps icc.  mpicc and mpigcc wrap gcc.
-MPICC=mpiicc -std=c99
+MPIDIR=/opt/intel/inteloneapi/mpi/2021.1-beta06
+MPICC=${MPIDIR}/bin/mpiicc
+MPICXX=${MPIDIR}/bin/mpiicpc
+MPIINC=-I${MPIDIR}/include
+MPILIB=-L${MPIDIR}/lib -lmpi
+#MPILIB=-L/usr/local/opt/libevent/lib -L${MPIDIR}/lib -lmpi
+#MPIINC=-I/usr/include/mpich-3.2-x86_64
+#MPILIB=-L/usr/lib64/mpich-3.2/lib -lmpi
+#
+# Global Arrays
+#
+GADIR=../deps/ga
+GAFLAG=-I${GADIR}/include
+GAFLAG+=-L${GADIR}/lib -lga
+GAFLAG+=-L${GADIR}/../armci-mpi/lib -larmci # ARMCI-MPI
+#GAFLAG+=-L${GADIR}/lib -larmci -lcomex     # ARMCI/ComEx
+GAFLAG+=${MPIINC} ${MPILIB}
+GAFLAG+=-lmpifort -lmpi
+GAFLAG+=-i8 # GA is compiled with -i8 on 64-bit systems
+#
+# PETSc
+#
+PETSCDIR=../deps/petsc
+PETSCFLAG=-I${PETSCDIR}/include
+PETSCFLAG+=-L${PETSCDIR}/lib -lpetsc
+PETSCFLAG+=-Wl,-rpath=${PETSCDIR}/lib
 #
 # Fortran 2008 coarrays
 #

--- a/common/make.defs.llvm
+++ b/common/make.defs.llvm
@@ -185,6 +185,7 @@ NVCC=/opt/llvm/cocl/bin/cocl
 # Linux w/ NVIDIA CUDA
 #NVCC=nvcc -arch=sm_50
 CUDAFLAGS=-g -O3 -std=c++11
+CUDAFLAGS+=-arch=sm_50
 # https://github.com/tensorflow/tensorflow/issues/1066#issuecomment-200574233
 CUDAFLAGS+=-D_MWAITXINTRIN_H_INCLUDED
 #
@@ -205,7 +206,7 @@ ISPCFLAG=-O3 --target=host --opt=fast-math
 #
 # MPI-3
 #
-MPIDIR=/usr/local
+MPIDIR=/usr
 MPICC=${MPIDIR}/bin/mpicc
 MPICXX=${MPIDIR}/bin/mpicxx
 MPIINC=-I${MPIDIR}/include
@@ -213,6 +214,26 @@ MPILIB=-L${MPIDIR}/lib -lmpi
 #MPILIB=-L/usr/local/opt/libevent/lib -L${MPIDIR}/lib -lmpi
 #MPIINC=-I/usr/include/mpich-3.2-x86_64
 #MPILIB=-L/usr/lib64/mpich-3.2/lib -lmpi
+#
+# Global Arrays
+#
+GADIR=../deps/ga
+GAFLAG=-I${GADIR}/include
+GAFLAG+=-L${GADIR}/lib -lga
+GAFLAG+=-L${GADIR}/../armci-mpi/lib -larmci # ARMCI-MPI
+#GAFLAG+=-L${GADIR}/lib -larmci -lcomex     # ARMCI/ComEx
+GAFLAG+=${MPIINC} ${MPILIB}
+GAFLAG+=-lmpifort -lmpi
+GAFLAG+=-i8 # GA is compiled with -i8 on 64-bit systems
+#
+# PETSc
+#
+PETSCDIR=../deps/petsc
+PETSCFLAG=-I${PETSCDIR}/include
+PETSCFLAG+=-L${PETSCDIR}/lib -lpetsc
+PETSCFLAG+=-Wl,-rpath=${PETSCDIR}/lib
+#
+# MEMKIND (used in C1z)
 #
 MEMKINDDIR=/home/parallels/PRK/deps
 MEMKINDFLAGS=-I${MEMKINDDIR}/include -L${MEMKINDDIR}/lib -lmemkind -Wl,-rpath=${MEMKINDDIR}/lib

--- a/common/make.defs.oneapi
+++ b/common/make.defs.oneapi
@@ -77,6 +77,7 @@ THRUSTFLAG=-I${THRUSTDIR} ${RANGEFLAG}
 #
 #CBLASFLAG=-DACCELERATE -framework Accelerate -flax-vector-conversions
 CBLASFLAG=-DMKL -mkl
+ONEMKLFLAG=-I$(MKLROOT)/include -DMKL_ILP64 ${MKLROOT}/lib/intel64/libmkl_sycl.a  -L${MKLROOT}/lib/intel64 -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lOpenCL -ldl
 #
 # CUDA flags
 #
@@ -102,13 +103,31 @@ ISPCFLAG=-O3 --target=host --opt=fast-math
 #
 # mpiicc wraps icc.  mpicc and mpigcc wrap gcc.
 MPIDIR=/opt/intel/inteloneapi/mpi/2021.1-beta06
-MPICC=${MPIDIR}/bin/mpicc
-MPICXX=${MPIDIR}/bin/mpicxx
+MPICC=${MPIDIR}/bin/mpiicc
+MPICXX=${MPIDIR}/bin/mpiicpc
 MPIINC=-I${MPIDIR}/include
 MPILIB=-L${MPIDIR}/lib -lmpi
 #MPILIB=-L/usr/local/opt/libevent/lib -L${MPIDIR}/lib -lmpi
 #MPIINC=-I/usr/include/mpich-3.2-x86_64
 #MPILIB=-L/usr/lib64/mpich-3.2/lib -lmpi
+#
+# Global Arrays
+#
+GADIR=../deps/ga
+GAFLAG=-I${GADIR}/include
+GAFLAG+=-L${GADIR}/lib -lga
+GAFLAG+=-L${GADIR}/../armci-mpi/lib -larmci # ARMCI-MPI
+#GAFLAG+=-L${GADIR}/lib -larmci -lcomex     # ARMCI/ComEx
+GAFLAG+=${MPIINC} ${MPILIB}
+GAFLAG+=-lmpifort -lmpi
+GAFLAG+=-i8 # GA is compiled with -i8 on 64-bit systems
+#
+# PETSc
+#
+PETSCDIR=../deps/petsc
+PETSCFLAG=-I${PETSCDIR}/include
+PETSCFLAG+=-L${PETSCDIR}/lib -lpetsc
+PETSCFLAG+=-Wl,-rpath=${PETSCDIR}/lib
 #
 # MEMKIND (used in C1z)
 #


### PR DESCRIPTION
This is slow with MPI because of PETSc and doesn't check for correctness.

## New PRK implementation checklist

### Which kernels are implemented?

- [ ] synch_p2p (p2p)
- [ ] stencil
- [x] transpose
- [ ] nstream
- [ ] dgemm
- [ ] reduce
- [ ] sparse
- [ ] branch
- [ ] random
- [ ] refcount
- [ ] synch_global
- [ ] PIC
- [ ] AMR
