### PR TITLE
[SYCL][USM] Fix byte size calculation

### DIFF
--- a/Cxx11/nstream-sycl-explicit-usm.cc
+++ b/Cxx11/nstream-sycl-explicit-usm.cc
@@ -93,7 +93,7 @@ void run(sycl::queue & q, int iterations, size_t length)
     T * d_C = syclx::malloc_device<T>(length, q);
     q.wait();
 
-    const size_t bytes = length * sizeof(double);
+    const size_t bytes = length * sizeof(T);
 
     q.memcpy(d_A, &(h_A[0]), bytes);
     q.memcpy(d_B, &(h_B[0]), bytes);


### PR DESCRIPTION
Signed-off-by: James Brodman <james.brodman@intel.com>

If this pull request is fixing a bug, please link the associated issue.
The rest of this template does not apply.

If this pull request is providing a new implementation of the PRKs,
please use the following template.

Note that checking all of the boxes is not required.
In some cases, only one box may be checked, *and that is totally fine.*

## New PRK implementation checklist

### Which kernels are implemented?

- [ ] synch_p2p (p2p)
- [ ] stencil
- [ ] transpose
- [X ] nstream
- [ ] dgemm
- [ ] reduce
- [ ] sparse
- [ ] branch
- [ ] random
- [ ] refcount
- [ ] synch_global
- [ ] PIC
- [ ] AMR

### Is Travis CI supported?

- [ ] Yes
- [ ] No
- [X] I dunno, Jeff.
If no, why not?

There are many good reasons why Travis CI support may not be part of your PR.
You or someone else can always add it later.
In many cases, we will add it later

### Documentation and build examples

If your implementation uses a new programming model that is not
ubiquitious (i.e. included in the system compiler on most systems)
then you need to provide a link to the appropriate documentation
for a new user to install it, etc.

We strongly recommend that you add the appropriate features
to `make.defs.${toolchain}` if appropriate.
