### PR TITLE
make input parsing work with older C# compilers

### DIFF
--- a/Csharp/nstream.cs
+++ b/Csharp/nstream.cs
@@ -86,17 +86,8 @@ namespace PRK {
           System.Environment.Exit(args.Length+1);
       }
 
-      if ( int.TryParse(args[0], out int iterations) ) {
-          Console.WriteLine("Number of iterations  = {0}", iterations);
-      } else {
-          Help();
-      }
-
-      if ( int.TryParse(args[1], out int length) ) {
-          Console.WriteLine("vector length         = {0}", length);
-      } else {
-          Help();
-      }
+      int iterations = int.Parse(args[0]);
+      int length     = int.Parse(args[1]);
 
       //////////////////////////////////////////////////////////////////////
       // Allocate space and perform the computation

--- a/Csharp/transpose.cs
+++ b/Csharp/transpose.cs
@@ -78,17 +78,15 @@ namespace PRK {
           System.Environment.Exit(args.Length+1);
       }
 
-      if ( int.TryParse(args[0], out int iterations) ) {
-          Console.WriteLine("Number of iterations = {0}", iterations);
-      } else {
-          Help();
-      }
+      // This requires a newer C# compiler than 4.6 (e.g. 6.8)
+      //if ( int.TryParse(args[0], out int iterations) ) {
+      //    Console.WriteLine("Number of iterations = {0}", iterations);
+      //} else {
+      //    Help();
+      //}
 
-      if ( int.TryParse(args[1], out int order) ) {
-          Console.WriteLine("Matrix order         = {0}", order);
-      } else {
-          Help();
-      }
+      int iterations = int.Parse(args[0]);
+      int order      = int.Parse(args[1]);
 
       //////////////////////////////////////////////////////////////////////
       // Allocate space for the input and transpose matrix


### PR DESCRIPTION
MCS 4.6 on Ubuntu 18 AAarch64 didn't like the previous implementation and I am fine with trading potential robustness for portability.