### PR TITLE
Fixed device numbers for memory APIs.

### DIFF
--- a/C1z/nstream-alloc-target.c
+++ b/C1z/nstream-alloc-target.c
@@ -95,8 +95,8 @@ int main(int argc, char * argv[])
     return 1;
   }
 
-  int device = (argc > 3) ? atol(argv[3]) : omp_get_initial_device();
-  if ( (device < 0 || omp_get_num_devices() <= device ) && (device != omp_get_initial_device()) ) {
+  int device = (argc > 3) ? atol(argv[3]) : omp_get_default_device();
+  if ( (device < 0 || omp_get_num_devices() <= device ) && (device != omp_get_default_device()) ) {
     printf("ERROR: device number %d is not valid.\n", device);
     return 1;
   }

--- a/C1z/nstream-memcpy-target.c
+++ b/C1z/nstream-memcpy-target.c
@@ -127,9 +127,9 @@ int main(int argc, char * argv[])
       h_C[i] = 2.0;
   }
 
-  double * restrict d_A = omp_target_alloc(bytes, host);
-  double * restrict d_B = omp_target_alloc(bytes, host);
-  double * restrict d_C = omp_target_alloc(bytes, host);
+  double * restrict d_A = omp_target_alloc(bytes, device);
+  double * restrict d_B = omp_target_alloc(bytes, device);
+  double * restrict d_C = omp_target_alloc(bytes, device);
 
   int rc = 0;
   rc = omp_target_memcpy(d_A, h_A, bytes, 0, 0, device, host);

--- a/C1z/nstream-usm-target.c
+++ b/C1z/nstream-usm-target.c
@@ -95,8 +95,8 @@ int main(int argc, char * argv[])
     return 1;
   }
 
-  int device = (argc > 3) ? atol(argv[3]) : omp_get_initial_device();
-  if ( (device < 0 || omp_get_num_devices() <= device ) && (device != omp_get_initial_device()) ) {
+  int device = (argc > 3) ? atol(argv[3]) : omp_get_default_device();
+  if ( (device < 0 || omp_get_num_devices() <= device ) && (device != omp_get_default_device()) ) {
     printf("ERROR: device number %d is not valid.\n", device);
     return 1;
   }


### PR DESCRIPTION
Signed-off-by: Vyacheslav Zakharin <vyacheslav.p.zakharin@intel.com>

If this pull request is fixing a bug, please link the associated issue.
The rest of this template does not apply.

If this pull request is providing a new implementation of the PRKs,
please use the following template.

Note that checking all of the boxes is not required.

## New PRK implementation checklist

### Which kernels are implemented?

- [ ] synch_p2p (p2p)
- [ ] stencil
- [ ] transpose
- [ ] nstream
- [ ] dgemm
- [ ] reduce
- [ ] sparse
- [ ] branch
- [ ] random
- [ ] refcount
- [ ] synch_global
- [ ] PIC
- [ ] AMR

### Documentation and build examples

If your implementation uses a new programming model that is not
ubiquitious (i.e. included in the system compiler on most systems)
then you need to provide a link to the appropriate documentation
for a new user to install it, etc.

We strongly recommend that you add the appropriate features
to `make.defs.${toolchain}` if appropriate.

### Do you certify that your contribution is made in good faith and does not attempt to introduce any negative behavior into this project?

- [X ] Yes
- [ ] No
