### PR TITLE
Place omp_target_free after the last use of the memory.

### DIFF
--- a/C1z/nstream-memcpy-target.c
+++ b/C1z/nstream-memcpy-target.c
@@ -139,9 +139,6 @@ int main(int argc, char * argv[])
   rc = omp_target_memcpy(d_C, h_C, bytes, 0, 0, device, host);
   if (rc) { printf("ERROR: omp_target_memcpy(C) returned %d\n", rc); abort(); }
 
-  omp_target_free(h_C, host);
-  omp_target_free(h_B, host);
-
   {
     for (int iter = 0; iter<=iterations; iter++) {
 
@@ -165,6 +162,8 @@ int main(int argc, char * argv[])
   omp_target_free(d_C, device);
   omp_target_free(d_B, device);
   omp_target_free(d_A, device);
+  omp_target_free(h_C, host);
+  omp_target_free(h_B, host);
 
   //////////////////////////////////////////////////////////////////////
   /// Analyze and output results


### PR DESCRIPTION
`h_C` and `h_B` are used after the point of the original `omp_target_free` calls.  With this, `nstream-memcpy-target` passes on CML GEN11 with `10 10` input.