### PR TITLE
nstream-numba: get good performance by pulling 0th iteration call out of loop

### DIFF
--- a/PYTHON/nstream-numba.py
+++ b/PYTHON/nstream-numba.py
@@ -75,17 +75,9 @@ print('Numpy version  = ', numpy.version.version)
 
 
 @jit
-def nstream(length,A, B, C, scalar):
-    # range vs ndindex makes no difference on performance
-    #for i in range(0,length):
-    for i in numpy.ndindex(length):
+def nstream(length, A, B, C, scalar):
+    for i in range(length):
         A[i] += B[i] + scalar * C[i]
-
-    # this is slower
-    #A += B + scalar * C
-
-    # this is slowest
-    #A[:] += B[:] + scalar * C[:]
 
 
 def main():
@@ -128,13 +120,12 @@ def main():
 
     scalar = 3.0
 
-    for k in range(0,iterations+1):
+    nstream(length, A, B, C, scalar)
+    t0 = timer()
+    #A += B + scalar * C
 
-        if k<1: t0 = timer()
-
-        #A += B + scalar * C
-        nstream(length,A,B,C,scalar)
-
+    for k in range(iterations):
+        nstream(length, A, B, C, scalar)
 
     t1 = timer()
     nstream_time = t1 - t0


### PR DESCRIPTION
If this pull request is fixing a bug, please link the associated issue.
The rest of this template does not apply.

If this pull request is providing a new implementation of the PRKs,
please use the following template.

Note that checking all of the boxes is not required.

## New PRK implementation checklist

### Which kernels are implemented?

- [ ] synch_p2p (p2p)
- [ ] stencil
- [ ] transpose
- [x] nstream
- [ ] dgemm
- [ ] reduce
- [ ] sparse
- [ ] branch
- [ ] random
- [ ] refcount
- [ ] synch_global
- [ ] PIC
- [ ] AMR

### Documentation and build examples

If your implementation uses a new programming model that is not
ubiquitious (i.e. included in the system compiler on most systems)
then you need to provide a link to the appropriate documentation
for a new user to install it, etc.

We strongly recommend that you add the appropriate features
to `make.defs.${toolchain}` if appropriate.

### Do you certify that your contribution is made in good faith and does not attempt to introduce any negative behavior into this project?

- [x] Yes
- [ ] No


Before:
```
python PYTHON/nstream-numba.py 100 100000
Python version =  3.7
Numpy version  =  1.16.4
Parallel Research Kernels version 
Python Numpy STREAM triad: A = B + scalar * C
Number of iterations =  100
Vector length        =  100000
Solution validates
Rate (MB/s):  1787.9912007142032  Avg time (s):  0.0017897179800000008
```

After:
```
python PYTHON/nstream-numba.py 100 100000
Python version =  3.7
Numpy version  =  1.16.4
Parallel Research Kernels version 
Python Numpy STREAM triad: A = B + scalar * C
Number of iterations =  100
Vector length        =  100000
Solution validates
Rate (MB/s):  35320.83292264001  Avg time (s):  9.059808999999142e-05
```