### PR TITLE
add GPU_SCHEDULE to Fortran nstream-openmp-target

### DIFF
--- a/FORTRAN/nstream-openmp-target.F90
+++ b/FORTRAN/nstream-openmp-target.F90
@@ -144,13 +144,13 @@ program main
 
   t0 = 0
 
-  !$omp parallel do simd
+  !$omp parallel do
   do i=1,length
     A(i) = 0
     B(i) = 2
     C(i) = 2
   enddo
-  !$omp end parallel do simd
+  !$omp end parallel do
 
   !$omp target data map(tofrom: A) map(to: B,C) map(to:length)
 
@@ -158,7 +158,7 @@ program main
 
     if (k.eq.1) t0 = omp_get_wtime()
 
-    !$omp target teams distribute parallel do simd
+    !$omp target teams distribute parallel do simd GPU_SCHEDULE
     do i=1,length
       A(i) = A(i) + B(i) + scalar * C(i)
     enddo

--- a/common/make.defs.cray
+++ b/common/make.defs.cray
@@ -20,6 +20,7 @@ DEFAULT_OPT_FLAGS=-O2
 OPENMPFLAG=-h omp
 # Cray requires 'module load craype-accel-host' or similar
 OFFLOADFLAG=-h omp
+OFFLOADFLAG+=-DGPU_SCHEDULE=""
 OPENACCFLAG=-h acc
 #
 # Parallel STL, Boost, etc.

--- a/common/make.defs.cuda
+++ b/common/make.defs.cuda
@@ -33,6 +33,7 @@ DEFAULT_OPT_FLAGS+=-Wno-ignored-attributes -Wno-deprecated-declarations
 OPENMPFLAG=-fopenmp
 OPENMPSIMDFLAG=-fopenmp-simd
 OFFLOADFLAG=-foffload="-O3 -v"
+OFFLOADFLAG+=-DGPU_SCHEDULE="schedule(static,1)"
 OPENACCFLAG=-fopenacc
 #
 # OpenCL flags

--- a/common/make.defs.gcc
+++ b/common/make.defs.gcc
@@ -38,6 +38,7 @@ DEFAULT_OPT_FLAGS+=-Wno-ignored-attributes -Wno-deprecated-declarations # silenc
 OPENMPFLAG=-fopenmp
 OPENMPSIMDFLAG=-fopenmp-simd
 OFFLOADFLAG=-foffload="-O3 -v"
+OFFLOADFLAG+=-DGPU_SCHEDULE=""
 OPENACCFLAG=-fopenacc
 #
 # OpenCL flags

--- a/common/make.defs.hip
+++ b/common/make.defs.hip
@@ -25,6 +25,7 @@ OPENMPFLAG=-fopenmp
 OPENMPSIMDFLAG=-fopenmp-simd
 #GCC#OFFLOADFLAG=-foffload=amdgcn-amdhsa="-march=fiji"
 OFFLOADFLAG=-fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908
+OFFLOADFLAG+=-DGPU_SCHEDULE="schedule(static,1)" # makes ~10x diff with AMD Flang 12 on MI-100
 OPENACCFLAG=-fopenacc $(OFFLOADFLAG)
 #
 # OpenCL flags
@@ -74,8 +75,8 @@ THRUSTFLAG=-I${THRUSTDIR} ${RANGEFLAG}
 #
 # CBLAS for C++ DGEMM
 #
-BLASFLAG=
-CBLASFLAG=
+BLASFLAG=-L${HOME}/BLIS/zen2-gcc/lib -lblis
+CBLASFLAG=-I${HOME}/BLIS/zen2-gcc/include
 #
 # CUDA flags
 #

--- a/common/make.defs.intel
+++ b/common/make.defs.intel
@@ -31,6 +31,7 @@ DEFAULT_OPT_FLAGS=-g -O3 -xHOST
 OPENMPFLAG=-qopenmp
 OPENMPSIMDFLAG=-qopenmp-simd
 OFFLOADFLAG=-qopenmp-offload=host
+OFFLOADFLAG+=-DGPU_SCHEDULE=""
 #
 # OpenCL flags
 #

--- a/common/make.defs.llvm
+++ b/common/make.defs.llvm
@@ -41,6 +41,7 @@ DEFAULT_OPT_FLAGS+=-Wno-ignored-attributes -Wno-deprecated-declarations
 OPENMPFLAG=-fopenmp
 OPENMPSIMDFLAG=-fopenmp-simd
 OFFLOADFLAG=-fopenmp
+OFFLOADFLAG+=-DGPU_SCHEDULE=""
 #OPENACCFLAG= # Flang does not support OpenACC
 # Klondike weirdness
 # OPENMPFLAG+=-L/opt/intel/compilers_and_libraries_2018.0.082/linux/compiler/lib/intel64_lin -liomp5

--- a/common/make.defs.nvhpc
+++ b/common/make.defs.nvhpc
@@ -21,6 +21,7 @@ DEFAULT_OPT_FLAGS+=-Wall #-Werror
 OPENMPFLAG=-mp #-Minfo=mp,vect
 OPENMPSIMDFLAG=-mp #-Minfo=mp,vect
 OFFLOADFLAG=-mp #-ta=multicore #-Minfo=mp,vect
+OFFLOADFLAG+=-DGPU_SCHEDULE="schedule(static,1)"
 OPENACCFLAG=-acc #-ta=multicore #-Minfo=accel
 #OPENACCFLAG=-acc -ta=tesla:cc70 -Minfo=accel
 OPENACCFLAG+=-Mlarge_arrays

--- a/common/make.defs.oneapi
+++ b/common/make.defs.oneapi
@@ -31,6 +31,7 @@ DEFAULT_OPT_FLAGS=-g -O3 -xHOST
 OPENMPFLAG=-fiopenmp
 OPENMPSIMDFLAG=-qopenmp-simd
 OFFLOADFLAG=-fopenmp-targets=spir64
+OFFLOADFLAG+=-DGPU_SCHEDULE=""
 #
 # OpenCL flags
 #

--- a/common/make.defs.pgi
+++ b/common/make.defs.pgi
@@ -20,6 +20,7 @@ DEFAULT_OPT_FLAGS=-O2 -tp=haswell
 OPENMPFLAG=-mp #-Minfo=mp,vect
 OPENMPSIMDFLAG=-mp #-Minfo=mp,vect
 OFFLOADFLAG=-mp -ta=multicore #-Minfo=mp,vect
+OFFLOADFLAG+=-DGPU_SCHEDULE=""
 OPENACCFLAG=-acc -ta=multicore #-Minfo=accel
 #OPENACCFLAG=-acc -ta=tesla:cc70 -Minfo=accel
 OPENACCFLAG+=-Mlarge_arrays


### PR DESCRIPTION
AMD Flang really needs `schedule(static,1)`.  Thanks @mjklemm.