### PR TITLE
Small Julia fixes

### DIFF
--- a/JULIA/stencil.jl
+++ b/JULIA/stencil.jl
@@ -191,7 +191,7 @@ function main()
     else
         precompile(do_stencil, (Array{Float64,2}, Array{Float64,2}, Array{Float64,2}, Int64, Int64))
     end
-    precompile(do_add, (Array{Float64,2}, Int64))
+    precompile(do_add!, (Array{Float64,2}, Int64))
 
     A = zeros(Float64,n,n)
     B = zeros(Float64,n,n)
@@ -209,7 +209,7 @@ function main()
         else
             do_stencil(A, W, B, r, n)
         end
-        do_add(A, n)
+        do_add!(A, n)
     end
 
     t1 = time_ns()

--- a/JULIA/stencil.jl
+++ b/JULIA/stencil.jl
@@ -61,10 +61,10 @@
 #
 # *******************************************************************
 
-function do_add(A, n)
-    for i=1:n
-        for j=1:n
-            A[i,j] += 1.0
+function do_add!(A, n)
+	for j = Base.OneTo(n)
+		for i = Base.OneTo(n)
+			@inbounds A[i,j] += one(eltype(A))
         end
     end
 end

--- a/JULIA/stencil.jl
+++ b/JULIA/stencil.jl
@@ -62,9 +62,9 @@
 # *******************************************************************
 
 function do_add!(A, n)
-	for j = Base.OneTo(n)
-		for i = Base.OneTo(n)
-			@inbounds A[i,j] += one(eltype(A))
+	for j = axes(A, 2)
+		for i = axes(A, 1)
+			@inbounds A[i,j] += oneunit(A)
         end
     end
 end

--- a/JULIA/stencil.jl
+++ b/JULIA/stencil.jl
@@ -64,7 +64,7 @@
 function do_add!(A, n)
 	for j = axes(A, 2)
 		for i = axes(A, 1)
-			@inbounds A[i,j] += oneunit(A)
+			@inbounds A[i,j] += one(eltype(A))
         end
     end
 end


### PR DESCRIPTION
### Do you certify that your contribution is made in good faith and does not attempt to introduce any negative behavior into this project?

- [X] Yes
- [ ] No

I just saw this thread on [twitter](https://twitter.com/science_dot/status/1375115999997927426), so I might as well chip in a bit.

Changes:
1. `do_add` -> `do_add!` : When a function mutates its arguments (`A` in this case), it is Julia convention to add a `!` at the end of the function name to alert the user.
2. Switching the loop order - Julia is column major, and this incurs a heavy performance hit.
3. `1:n` -> `Base.OneTo(n)` This method uses a type to tell the compiler that the loops start at `1`, which is very useful for loop unrolling and SIMD shenanigans. Usually not worth it if it's not a super tight loop.
4. `@inbounds` elides bounds checking.
5. `1.0` to `one(eltype(A))`: This calls a function which determines what is the `identity` element for the collection of A. This is especially useful to guarantee [type stability](https://docs.julialang.org/en/v1/manual/performance-tips/) of Julia code. This is especially relevant when doing floating point operations since `1.0` is interpreted as a `Float64`, and therefore all the floats get widened to `Float64`, even if we passed in a `Float32` array. The timings below should make the difference very clear.

```julia
# Alternative broadcasting syntax - not fastest, but compact and nifty
julia> @btime A .+= 1.0;
   671.889 μs (2 allocations: 64 bytes)

julia> function do_add(A, n)
           for i=1:n
               for j=1:n
                   A[i,j] += 1.0
               end
           end
       end
do_add (generic function with 1 method)


julia> A = [rand() for i in 1:1000, j in 1:1000];

julia> Afloat32 = [rand(Float32) for i in 1:1000, j in 1:1000];

julia> @btime do_add($A, 1000);
  2.720 ms (0 allocations: 0 bytes)

# We should be getting a much larger perf boost from Float32's
julia> @btime do_add($Afloat32, 1000);
  1.970 ms (0 allocations: 0 bytes)

# Switching the loops
julia> function do_add2!(A, n)
            for j=1:n
                for i=1:n
                    A[i,j] += 1.0
                end
            end
        end
 do_add2! (generic function with 1 method)

# About a 3-4x gain
 julia> @btime do_add2!($A, 1000);
   678.599 μs (0 allocations: 0 bytes)

 julia> function do_add3!(A, n)
            for j=1:n
                for i=1:n
                    @inbounds A[i,j] += 1.0
                end
            end
        end
 do_add3! (generic function with 1 method)

 julia> @btime do_add3!($A, 1000);
   605.119 μs (0 allocations: 0 bytes)

# This is equivalent to the one in the PR
julia> function do_add4!(A)
           n = size(A, 1)
           for j = Base.OneTo(n)
               for i = Base.OneTo(n)
                   @inbounds A[i,j] += one(eltype(A))
               end
           end
       end
do_add4! (generic function with 1 method)

julia> @btime do_add4!($A);
  499.562 μs (0 allocations: 0 bytes)

# PR version
julia> @btime do_add4!($Afloat32);
  181.395 μs (0 allocations: 0 bytes)

```

TL;DR - I highly recommend reading the [performance tips](https://docs.julialang.org/en/v1/manual/performance-tips/) of the manual, almost nothing I did here is not written there.
We gained about 15x and made our code type stable and generic - you can probably get this to run on GPUs without [too much additional effort](https://juliagpu.github.io/CUDA.jl/stable/tutorials/introduction/#Writing-your-first-GPU-kernel), but that's a PR for a different day.

My laptop specs:
```
julia> versioninfo()
Julia Version 1.6.0-rc2
Commit 4b6b9fe4d7 (2021-03-11 07:05 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: Intel(R) Core(TM) i7-4710HQ CPU @ 2.50GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-11.0.1 (ORCJIT, haswell)
```