### PR TITLE
Kokkos CUDA fixes

### DIFF
--- a/Cxx11/Makefile
+++ b/Cxx11/Makefile
@@ -232,7 +232,7 @@ pic-sycl: pic-sycl.cc prk_util.h prk_sycl.h random_draw.c
 
 ifeq ($(PRK_KOKKOS_BACKEND),Cuda)
 %-kokkos: %-kokkos.cc prk_util.h prk_kokkos.h
-	${KOKKOSDIR}/bin/nvcc_wrapper $(CPPFLAGS) $(CUDAFLAGS) $< $(KOKKOSFLAG) -DPRK_KOKKOS_BACKEND=Cuda -o $@
+	$(NVCC) -x cu $(CPPFLAGS) $(CUDAFLAGS) $< $(KOKKOSFLAG) -DPRK_KOKKOS_BACKEND=Cuda -o $@
 else
 %-kokkos: %-kokkos.cc prk_util.h prk_kokkos.h
 	$(info PRK help: Set USE_PRK_KOKKOS_BACKEND={Threads,Serial,Cuda} when invoking make to not use OpenMP)

--- a/Cxx11/nstream-kokkos.cc
+++ b/Cxx11/nstream-kokkos.cc
@@ -163,7 +163,8 @@ int main(int argc, char * argv[])
 
     double asum(0);
     Kokkos::parallel_reduce(length, KOKKOS_LAMBDA(size_t const i, double & inner) {
-        inner += prk::abs(A(i));
+        using Kokkos::Experimental::fabs;
+        inner += fabs(A(i));
     }, asum);
     Kokkos::fence();
 

--- a/Cxx11/prk_kokkos.h
+++ b/Cxx11/prk_kokkos.h
@@ -35,5 +35,6 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Concepts.hpp>
 #include <Kokkos_MemoryTraits.hpp>
+#include <Kokkos_MathematicalFunctions.hpp>
 
 #endif /* PRK_KOKKOS_H */

--- a/Cxx11/stencil-kokkos.cc
+++ b/Cxx11/stencil-kokkos.cc
@@ -81,7 +81,7 @@ int main(int argc, char* argv[])
   std::cout << "Parallel Research Kernels version " << PRKVERSION << std::endl;
   std::cout << "C++11/Kokkos Stencil execution on 2D grid" << std::endl;
 
-  Kokkos::initialize (argc, argv);
+  Kokkos::initialize(argc, argv);
   {
     //////////////////////////////////////////////////////////////////////
     // Process and test input parameters
@@ -94,7 +94,6 @@ int main(int argc, char* argv[])
           throw "Usage: <# iterations> <array dimension> [<tile_size> <star/grid> <radius>]";
         }
 
-        // number of times to run the algorithm
         iterations  = std::atoi(argv[1]);
         if (iterations < 1) {
           throw "ERROR: iterations must be >= 1";
@@ -175,10 +174,7 @@ int main(int argc, char* argv[])
     matrix in("in", n, n);
     matrix out("out", n, n);
 
-    auto z2     = {0,0};
-    auto n2     = {n,n};
-    auto tile2  = {tile_size,tile_size};
-    auto full   = Kokkos::MDRangePolicy<Kokkos::Rank<2>>(z2,n2,tile2);
+    auto full   = Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0,0},{n,n},{tile_size,tile_size});
 
     {
       Kokkos::parallel_for(full, KOKKOS_LAMBDA(int i, int j) {
@@ -210,12 +206,11 @@ int main(int argc, char* argv[])
 
     size_t active_points = static_cast<size_t>(n-2*radius)*static_cast<size_t>(n-2*radius);
 
-    double norm(0);
-    auto r2     = {radius,radius};
-    auto nr2    = {n-radius,n-radius};
-    auto inside = Kokkos::MDRangePolicy<Kokkos::Rank<2>>(r2,nr2,tile2);
+    double norm{0};
+    auto inside = Kokkos::MDRangePolicy<Kokkos::Rank<2>>({radius,radius},{n-radius,n-radius},{tile_size,tile_size});
     Kokkos::parallel_reduce(inside, KOKKOS_LAMBDA(int i, int j, double & norm) {
-        norm += prk::abs(out(i,j));
+        using Kokkos::Experimental::fabs;
+        norm += fabs(out(i,j));
     }, norm);
     Kokkos::fence();
     norm /= active_points;

--- a/Cxx11/transpose-kokkos.cc
+++ b/Cxx11/transpose-kokkos.cc
@@ -125,11 +125,11 @@ int main(int argc, char * argv[])
     auto order2 = {order,order};
     auto tile2  = {tile_size,tile_size};
 
-    auto policy    = Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0,0},order2,tile2);
+    const auto policy    = Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0,0}, {order,order}, {tile_size,tile_size});
     typedef Kokkos::Rank<2,Kokkos::Iterate::Right,Kokkos::Iterate::Left > rl;
     typedef Kokkos::Rank<2,Kokkos::Iterate::Left, Kokkos::Iterate::Right> lr;
-    auto policy_lr = Kokkos::MDRangePolicy<rl>({0,0},order2,tile2);
-    auto policy_rl = Kokkos::MDRangePolicy<lr>({0,0},order2,tile2);
+    const auto policy_lr = Kokkos::MDRangePolicy<rl>({0,0}, {order,order}, {tile_size,tile_size});
+    const auto policy_rl = Kokkos::MDRangePolicy<lr>({0,0}, {order,order}, {tile_size,tile_size});
 
     {
       Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int i, int j) {
@@ -170,12 +170,14 @@ int main(int argc, char * argv[])
     Kokkos::parallel_reduce(policy, KOKKOS_LAMBDA(int i, int j, double & update) {
         size_t const ij = i*order+j;
         double const reference = static_cast<double>(ij)*(1.+iterations)+addit;
-        update += prk::abs(B(j,i) - reference);
+        using Kokkos::Experimental::fabs;
+        update += fabs(B(j,i) - reference);
     }, abserr);
 
 #ifdef VERBOSE
     std::cout << "Sum of absolute differences: " << abserr << std::endl;
 #endif
+
 
     double epsilon(1.0e-8);
     if (abserr < epsilon) {
@@ -192,7 +194,6 @@ int main(int argc, char * argv[])
 
   }
   Kokkos::finalize();
-
   return 0;
 }
 

--- a/common/make.defs.nvhpc
+++ b/common/make.defs.nvhpc
@@ -49,17 +49,19 @@ BOOSTFLAG=
 #RANGEFLAG=-DUSE_BOOST_IRANGE ${BOOSTFLAG}
 RANGEFLAG=-DUSE_RANGES_TS -I../deps/range-v3/include
 PSTLFLAG=${OPENMPSIMDFLAG} ${TBBFLAG} -I./pstl/include ${RANGEFLAG}
-KOKKOSDIR=
-KOKKOSFLAG=-I${KOKKOSDIR}/include -L${KOKKOSDIR}/lib -lkokkos ${OPENMPFLAG}
+KOKKOSDIR=../deps/kokkos-cuda
+PRK_KOKKOS_BACKEND=Cuda
+KOKKOSCXX=${KOKKOSDIR}/bin/nvcc_wrapper
+KOKKOSFLAG=-I${KOKKOSDIR}/include -L${KOKKOSDIR}/lib -lkokkoscore
 RAJADIR=
 RAJAFLAG=-I${RAJADIR}/include -L${RAJADIR}/lib -lRAJA ${OPENMPFLAG} ${TBBFLAG}
-THRUSTDIR=../deps/thrust
+THRUSTDIR=/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/compilers/include-stdpar
 THRUSTFLAG=-I${THRUSTDIR}
 #
 # CBLAS for C++ DGEMM
 #
-BLASFLAG=
-CBLASFLAG=
+BLASFLAG=-L${NVHPC_PATH}/REDIST/compilers/lib -lblas
+CBLASFLAG=${BLASFLAG}
 #
 # CUDA flags
 #
@@ -67,9 +69,9 @@ CBLASFLAG=
 # Use appropriate arch or code is compiled to ancient features.
 #NVCC=${NVHPC_CBIN}nvc++
 NVCC=${NVHPC_CBIN}nvcc
-CUDAFLAGS=-g -O3 -std=c++14
+CUDAFLAGS=-g -O3 -std=c++17
 CUDAFLAGS+=--extended-lambda
-CUDAFLAGS+=--gpu-architecture=sm_70
+CUDAFLAGS+=--gpu-architecture=sm_75
 #CUDAFLAGS+=--compiler-bindir=/swtools/gcc/7.5.0/bin
 #CUDAFLAGS+=-forward-unknown-to-host-compiler -fopenmp
 CUDAFLAGS+=-rdc=true # FIXES ptxas fatal   : Unresolved extern function 'cudaCGGetIntrinsicHandle'


### PR DESCRIPTION
Apparently, `auto x={n,n}` can't be used in `MDRangePolicy` :-(