### PR TITLE
Fix Kokkos kernels for Kokkos 4.3.0

### DIFF
--- a/Cxx11/prk_kokkos.h
+++ b/Cxx11/prk_kokkos.h
@@ -33,8 +33,5 @@
 #define PRK_KOKKOS_H
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_Concepts.hpp>
-#include <Kokkos_MemoryTraits.hpp>
-#include <Kokkos_MathematicalFunctions.hpp>
 
 #endif /* PRK_KOKKOS_H */

--- a/Cxx11/stencil-kokkos.cc
+++ b/Cxx11/stencil-kokkos.cc
@@ -209,7 +209,7 @@ int main(int argc, char* argv[])
     double norm{0};
     auto inside = Kokkos::MDRangePolicy<Kokkos::Rank<2>>({radius,radius},{n-radius,n-radius},{tile_size,tile_size});
     Kokkos::parallel_reduce(inside, KOKKOS_LAMBDA(int i, int j, double & norm) {
-        using Kokkos::Experimental::fabs;
+        using Kokkos::fabs;
         norm += fabs(out(i,j));
     }, norm);
     Kokkos::fence();

--- a/Cxx11/transpose-kokkos.cc
+++ b/Cxx11/transpose-kokkos.cc
@@ -170,7 +170,7 @@ int main(int argc, char * argv[])
     Kokkos::parallel_reduce(policy, KOKKOS_LAMBDA(int i, int j, double & update) {
         size_t const ij = i*order+j;
         double const reference = static_cast<double>(ij)*(1.+iterations)+addit;
-        using Kokkos::Experimental::fabs;
+        using Kokkos::fabs;
         update += fabs(B(j,i) - reference);
     }, abserr);
 


### PR DESCRIPTION
Kokkos kernels don't compile under the latest release. Math functions such as fabs have been moved from the Kokkos::Experimental namespace to the Kokkos namespace. Additionally, directly including headers aside from Kokkos_Core.hpp is disallowed.

https://github.com/ParRes/Kernels/issues/640

### Do you certify that your contribution is made in good faith and does not attempt to introduce any negative behavior into this project?

- [X] Yes
- [ ] No
