### PR TITLE
Fix typo in Julia README.md

### DIFF
--- a/JULIA/README.md
+++ b/JULIA/README.md
@@ -8,7 +8,7 @@ julia --project -e 'using Pkg; Pkg.instantiate()'
 
 To get the `mpiexecjl` driver run:
 ```
-julia --project 'using MPI; MPI.install_mpiexecjl()'
+julia --project -e 'using MPI; MPI.install_mpiexecjl()'
 ```
 
 Afterwards, put '$HOME/.julia/bin' on `PATH`, e.g.


### PR DESCRIPTION
This PR fixes the `-e` typo pointed out by @jeffhammond in https://github.com/ParRes/Kernels/issues/646#issuecomment-2477403014_

With the typo fixed, I can **not** confirm/reproduce that the command (`using MPI; MPI.install_mpiexecjl()`) only works in the REPL and not via `-e`:

```
cb@mm ~/repos/Kernels/JULIA git:(main)
➜ JULIA_DEPOT_PATH=$(pwd)/.julia julia --project -e 'using MPI; MPI.install_mpiexecjl()'
[ Info: Installing `mpiexecjl` to `/Users/carstenbauer/repos/Kernels/JULIA/.julia/bin`...
[ Info: Done!
```