### PR TITLE
[SYCL] Cleanup example and eliminate warnings with recent DPC++ compiler ...

### DIFF
--- a/Cxx11/p2p-hyperplane-sycl.cc
+++ b/Cxx11/p2p-hyperplane-sycl.cc
@@ -154,8 +154,8 @@ int main(int argc, char* argv[])
           unsigned end   = std::min(i,n)+1;
           unsigned range = end-begin;
 
-          h.parallel_for<class sweep>(sycl::range<1>{range}, sycl::id<1>{begin}, [=] (sycl::item<1> j) {
-            auto J = j.get_id();
+          h.parallel_for<class sweep>(sycl::range<1>{range}, [=] (sycl::item<1> j) {
+            auto J = begin + j.get_id();
             sycl::id<1> N{unsigned(n)};
             sycl::id<1> X{I-J+One};
             sycl::id<1> Y{J-One};

--- a/Cxx11/p2p-hyperplane-sycl.cc
+++ b/Cxx11/p2p-hyperplane-sycl.cc
@@ -77,9 +77,6 @@ int main(int argc, char* argv[])
 
   int iterations;
   int n;
-#if 0
-  int nc, nb;
-#endif
   try {
       if (argc < 3) {
         throw " <# iterations> <array dimension> [<chunk dimension>]";
@@ -99,16 +96,6 @@ int main(int argc, char* argv[])
         throw "ERROR: grid dimension too large - overflow risk";
       }
 
-#if 0
-      // grid chunk dimensions
-      nc = (argc > 3) ? std::atoi(argv[3]) : 1;
-      nc = std::max(1,nc);
-      nc = std::min(n,nc);
-
-      // number of grid blocks
-      nb = (n-1)/nc;
-      if ((n-1)%nc) nb++;
-#endif
   }
   catch (const char * e) {
     std::cout << e << std::endl;
@@ -117,9 +104,6 @@ int main(int argc, char* argv[])
 
   std::cout << "Number of iterations = " << iterations << std::endl;
   std::cout << "Grid sizes           = " << n << ", " << n << std::endl;
-#if 0
-  std::cout << "Grid chunk sizes     = " << nc << std::endl;
-#endif
 
   //////////////////////////////////////////////////////////////////////
   // Allocate space and perform the computation
@@ -181,14 +165,6 @@ int main(int argc, char* argv[])
     q.wait();
     pipeline_time = prk::wtime() - pipeline_time;
   }
-
-#if 0
-  for (int i=0; i<n; ++i) {
-      for (int j=0; j<n; ++j) {
-          std::cout << i << "," << j << "=" << h_grid[i*n+j] << "\n";
-      }
-  }
-#endif
 
   //////////////////////////////////////////////////////////////////////
   // Analyze and output results.

--- a/Cxx11/prk_sycl.h
+++ b/Cxx11/prk_sycl.h
@@ -4,7 +4,11 @@
 #include <cstdlib>
 #include <iostream>
 
-#include "CL/sycl.hpp"
+#if __has_include(<sycl/sycl.hpp>)
+#    include <sycl/sycl.hpp>
+#else
+#    include <CL/sycl.hpp>
+#endif
 
 #if defined(__LIBSYCL_MAJOR_VERSION) && defined(__LIBSYCL_MINOR_VERSION) && defined(__LIBSYCL_PATCH_VERSION)
 #    define __LIBSYCL_VERSION                                                                                          \


### PR DESCRIPTION
- removing use of deprecated offsets (example only)
- using "sycl/sycl.hpp" if available (all sycl examples)
